### PR TITLE
Various fixes

### DIFF
--- a/core/include/jiminy/core/constraints/FixedFrameConstraint.h
+++ b/core/include/jiminy/core/constraints/FixedFrameConstraint.h
@@ -50,7 +50,7 @@ namespace jiminy
         void setReferenceTransform(pinocchio::SE3 const & transformRef);
         pinocchio::SE3 const & getReferenceTransform(void) const;
 
-        void setLocalFrame(matrix3_t const & frameRot);
+        void setNormal(vector3_t const & normal);
         matrix3_t const & getLocalFrame(void) const;
 
         virtual hresult_t reset(vectorN_t const & q,
@@ -64,6 +64,7 @@ namespace jiminy
         frameIndex_t frameIdx_;               ///< Corresponding frame index.
         std::vector<uint32_t> dofsFixed_;     ///< Degrees of freedom to fix.
         pinocchio::SE3 transformRef_;         ///< Reference pose of the frame to enforce.
+        vector3_t normal_;                    ///< Normal direction locally at the interface.
         matrix3_t rotationLocal_;             ///< Rotation matrix of the local frame in which to apply masking
         matrix6N_t frameJacobian_;            ///< Stores full frame jacobian in reference frame.
         pinocchio::Motion frameDrift_;        ///< Stores full frame drift in reference frame.

--- a/core/src/constraints/FixedFrameConstraint.cc
+++ b/core/src/constraints/FixedFrameConstraint.cc
@@ -24,7 +24,7 @@ namespace jiminy
     {
         dofsFixed_.resize(static_cast<std::size_t>(maskFixed.cast<int32_t>().array().sum()));
         uint32_t dofIndex = 0;
-        for (uint32_t i=0; i < 6; ++i)
+        for (uint32_t i : std::vector<uint32_t>{{3, 4, 5, 0, 1, 2}})
         {
             if (maskFixed[i])
             {

--- a/core/src/constraints/FixedFrameConstraint.cc
+++ b/core/src/constraints/FixedFrameConstraint.cc
@@ -18,7 +18,8 @@ namespace jiminy
     frameIdx_(0),
     dofsFixed_(),
     transformRef_(),
-    rotationLocal_(),
+    normal_(),
+    rotationLocal_(matrix3_t::Identity()),
     frameJacobian_(),
     frameDrift_()
     {
@@ -64,9 +65,12 @@ namespace jiminy
         return transformRef_;
     }
 
-    void FixedFrameConstraint::setLocalFrame(matrix3_t const & frameRot)
+    void FixedFrameConstraint::setNormal(vector3_t const & normal)
     {
-        rotationLocal_ = frameRot;
+        normal_ = normal;
+        rotationLocal_.col(2) = normal_;
+        rotationLocal_.col(1) = normal_.cross(vector3_t::UnitX()).normalized();
+        rotationLocal_.col(0) = rotationLocal_.col(1).cross(rotationLocal_.col(2));
     }
 
     matrix3_t const & FixedFrameConstraint::getLocalFrame(void) const

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -2959,9 +2959,7 @@ namespace jiminy
                         system.robot->pncData_.oMf[frameIdx].rotation(),
                         system.robot->pncData_.oMf[frameIdx].translation() - depth * nGround
                     });
-                    frameConstraint.setLocalFrame(
-                        quaternion_t::FromTwoVectors(vector3_t::UnitZ(), nGround).toRotationMatrix()
-                    );
+                    frameConstraint.setNormal(nGround);
 
                     // Only one contact constraint per collision body is supported for now
                     break;
@@ -3048,9 +3046,7 @@ namespace jiminy
                 system.robot->pncData_.oMf[frameIdx].rotation(),
                 (vector3_t() << posFrame.head<2>(), zGround).finished()
             });
-            frameConstraint.setLocalFrame(
-                quaternion_t::FromTwoVectors(vector3_t::UnitZ(), nGround).toRotationMatrix()
-            );
+            frameConstraint.setNormal(nGround);
         }
     }
 

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -3758,17 +3758,17 @@ namespace jiminy
                             return;
                         }
 
-                        // Friction cone in tangential plane
-                        hi[constraintIdx] = contactOptions.friction;
-                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 2),
-                                                   static_cast<int32_t>(constraintIdx + 1)};
-
                         // Torsional friction around normal axis
-                        hi[constraintIdx + 3] = contactOptions.torsion;
-                        fIndices[constraintIdx + 3] = {static_cast<int32_t>(constraintIdx + 2)};
+                        hi[constraintIdx] = contactOptions.torsion;
+                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 3)};
+
+                        // Friction cone in tangential plane
+                        hi[constraintIdx + 1] = contactOptions.friction;
+                        fIndices[constraintIdx + 1] = {static_cast<int32_t>(constraintIdx + 3),
+                                                       static_cast<int32_t>(constraintIdx + 2)};
 
                         // Non-penetration normal force
-                        lo[constraintIdx + 2] = 0.0;
+                        lo[constraintIdx + 3] = 0.0;
 
                         constraintIdx += constraint->getDim();
                     });
@@ -3857,8 +3857,8 @@ namespace jiminy
 
                 // Extract force in local reference-frame-aligned from lagrangian multipliers
                 pinocchio::Force fextInLocal(
-                    frameConstraint.lambda_.head<3>(),
-                    frameConstraint.lambda_[3] * vector3_t::UnitZ());
+                    frameConstraint.lambda_.tail<3>(),
+                    frameConstraint.lambda_[0] * vector3_t::UnitZ());
 
                 // Compute force in local world aligned frame
                 matrix3_t const & rotationLocal = frameConstraint.getLocalFrame();
@@ -3892,8 +3892,8 @@ namespace jiminy
 
                     // Extract force in world frame from lagrangian multipliers
                     pinocchio::Force fextInLocal(
-                        frameConstraint.lambda_.head<3>(),
-                        frameConstraint.lambda_[3] * vector3_t::UnitZ());
+                        frameConstraint.lambda_.tail<3>(),
+                        frameConstraint.lambda_[0] * vector3_t::UnitZ());
 
                     // Compute force in world frame
                     matrix3_t const & rotationLocal = frameConstraint.getLocalFrame();

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -1899,6 +1899,8 @@ namespace jiminy
                 {
                     dtNextGlobal = tEnd - t;
                 }
+
+                // Update next dt
                 tNext += dtNextGlobal;
 
                 // Compute the next step using adaptive step method
@@ -1920,18 +1922,29 @@ namespace jiminy
                         hasDynamicsChanged = false;
                     }
 
-                    /* Adjust stepsize to end up exactly at the next breakpoint,
-                       prevent steps larger than dtMax, trying to reach multiples of
-                       STEPPER_MIN_TIMESTEP whenever possible. The idea here is to
-                       reach only multiples of 1us, making logging easier, given that,
-                       in robotics, 1us can be consider an 'infinitesimal' time. This
-                       arbitrary threshold many not be suited for simulating different,
-                       faster dynamics, that require sub-microsecond precision. */
+                    // Adjust stepsize to end up exactly at the next breakpoint
                     dt = min(dt, tNext - t);
-                    if (tNext - (t + dt) < STEPPER_MIN_TIMESTEP)
+                    if (dtLargest > SIMULATION_MIN_TIMESTEP)
                     {
-                        dt = tNext - t;
+                        if (tNext - (t + dt) < SIMULATION_MIN_TIMESTEP)
+                        {
+                            dt = tNext - t;
+                        }
                     }
+                    else
+                    {
+                        if (tNext - (t + dt) < STEPPER_MIN_TIMESTEP)
+                        {
+                            dt = tNext - t;
+                        }
+                    }
+
+                    /* Trying to reach multiples of STEPPER_MIN_TIMESTEP whenever
+                       possible. The idea here is to reach only multiples of 1us,
+                       making logging easier, given that, 1us can be consider an
+                       'infinitesimal' time in robotics. This arbitrary threshold
+                       many not be suited for simulating different, faster
+                       dynamics, that require sub-microsecond precision. */
                     if (dt > SIMULATION_MIN_TIMESTEP)
                     {
                         float64_t const dtResidual = std::fmod(dt, SIMULATION_MIN_TIMESTEP);

--- a/core/src/solver/LCPSolvers.cc
+++ b/core/src/solver/LCPSolvers.cc
@@ -50,15 +50,18 @@ namespace jiminy
         // Update every coefficients sequentially
         for (uint32_t const & i : indices_)
         {
-            // Extract single coefficient
+            // Extract a single coefficient
             float64_t & e = x[i];
 
-            // Update a single coefficient
-            e += (b[i] - A.col(i).dot(x)) / A(i, i);
-
-            // Project the coefficient between lower and upper bounds
+            // Update the coefficient if relevant
             std::vector<int32_t> const & fIdx = fIndices[i];
             std::size_t const fSize = fIdx.size();
+            if ((fSize == 0 && (hi[i] - lo[i] > EPS)) || (hi[i] > EPS))
+            {
+                e += (b[i] - A.col(i).dot(x)) / A(i, i);
+            }
+
+            // Project the coefficient between lower and upper bounds
             if (fSize == 0)
             {
                 e = clamp(e, lo[i], hi[i]);

--- a/core/src/solver/LCPSolvers.cc
+++ b/core/src/solver/LCPSolvers.cc
@@ -134,34 +134,14 @@ namespace jiminy
            Note that it may converge faster to enforce constraints in reverse order,
            since usually constraints bounds dependending on others have lower indices
            by design, aka. coulomb friction law.
+           TODO: Avoid resetting it completely when the size changes.
            TODO: take into account the actual value of 'fIndices' to order the indices. */
         size_t const nIndices = b.size();
-        size_t const nIndicesOrig = indices_.size();
-        if (nIndicesOrig < nIndices)
+        if (indices_.size() != nIndices)
         {
             indices_.resize(nIndices);
-            std::generate(indices_.begin() + nIndicesOrig, indices_.end(),
+            std::generate(indices_.begin(), indices_.end(),
                           [n = static_cast<uint32_t>(nIndices - 1)]() mutable { return n--; });
-        }
-        else if (nIndicesOrig > nIndices)
-        {
-            size_t shiftIdx = nIndices;
-            for (size_t i = 0; i < nIndices; ++i)
-            {
-                if (static_cast<size_t>(indices_[i]) >= nIndices)
-                {
-                    for (size_t j = shiftIdx; j < nIndicesOrig; ++j)
-                    {
-                        ++shiftIdx;
-                        if (static_cast<size_t>(indices_[j]) < nIndices)
-                        {
-                            indices_[i] = indices_[j];
-                            break;
-                        }
-                    }
-                }
-            }
-            indices_.resize(nIndices);
         }
 
         // Normalizing

--- a/core/src/stepper/AbstractRungeKuttaStepper.cc
+++ b/core/src/stepper/AbstractRungeKuttaStepper.cc
@@ -79,10 +79,7 @@ namespace jiminy
                                                  state_t   const & /* solution */,
                                                  float64_t       & dt)
     {
-        /* Fixed-step by default, which never fails. By default INF is retuned
-           in case of fixed time step, so that the engine will always try to
-           perform the latest timestep possible, or stop to the next breakpoint
-           otherwise. */
+        // Fixed-step by default, which never fails
         dt = INF;
         return true;
     }

--- a/core/src/stepper/EulerExplicitStepper.cc
+++ b/core/src/stepper/EulerExplicitStepper.cc
@@ -19,6 +19,11 @@ namespace jiminy
         stateDerivative = f(t, state);
         state.sumInPlace(stateDerivative, dt);
 
+        /* By default INF is retuned in case of fixed time step, so that the
+           engine will always try to perform the latest timestep possible,
+           or stop to the next breakpoint otherwise. */
+        dt = INF;
+
         // Scheme never considers failure.
         return true;
     }

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -97,11 +97,11 @@ deployPythonPackage("${LIBRARY_NAME}_py")
 ################ gym_jiminy ################
 
 buildPythonWheel("python/gym_${LIBRARY_NAME}/common"
-                 "python/gym_${LIBRARY_NAME}/envs"
                  "python/gym_${LIBRARY_NAME}/toolbox"
+                 "python/gym_${LIBRARY_NAME}/envs"
                  "python/gym_${LIBRARY_NAME}/rllib"
                  "${CMAKE_BINARY_DIR}/pypi/dist/gym_${LIBRARY_NAME}")
 deployPythonPackageDevelop("python/gym_${LIBRARY_NAME}/common"
-                           "python/gym_${LIBRARY_NAME}/envs"
                            "python/gym_${LIBRARY_NAME}/toolbox"
+                           "python/gym_${LIBRARY_NAME}/envs"
                            "python/gym_${LIBRARY_NAME}/rllib")

--- a/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
@@ -37,9 +37,9 @@ PID_REDUCED_KP = np.array([
     5000.0, 5000.0, 8000.0, 4000.0, 8000.0, 5000.0])
 PID_REDUCED_KD = np.array([
     # Left leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.02, 0.01,
+    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01,
     # Right leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.02, 0.01])
+    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01])
 
 PID_FULL_KP = np.array([
     # Neck: [Y]

--- a/python/gym_jiminy/toolbox/setup.py
+++ b/python/gym_jiminy/toolbox/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),
     install_requires=[
-        f"gym_jiminy=={version}"
+        f"gym_jiminy_toolbox=={version}"
     ],
     zip_safe=False
 )

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -42,7 +42,7 @@ class PipelineControl(unittest.TestCase):
             :, self.env.controller.motor_to_encoder]
 
         # Run the simulation
-        while self.env.stepper_state.t < 12.0:
+        while self.env.stepper_state.t < 14.0:
             self.env.step(action_init)
 
         # Get the final posture of the robot as an RGB array

--- a/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
@@ -878,6 +878,23 @@ class Panda3dApp(panda3d_viewer.viewer_app.ViewerApp):
                     return
                 node.clear_render_mode()
 
+    def append_frame(self,
+                     root_path: str,
+                     name: str,
+                     frame: Optional[FrameType] = None) -> None:
+        """Append a cartesian frame primitive node to the group.
+        """
+        model = GeomNode('axes')
+        model.add_geom(geometry.make_axes())
+        node = NodePath(model)
+        node.set_light_off()
+        node.set_render_mode_wireframe()
+        node.set_render_mode_thickness(4)
+        node.set_antialias(AntialiasAttrib.MLine)
+        node.hide(self.LightMask)
+        node.set_shader_off()
+        self.append_node(root_path, name, node, frame)
+
     def append_cone(self,
                     root_path: str,
                     name: str,
@@ -1415,6 +1432,9 @@ class Panda3dViewer(panda3d_viewer.viewer.Viewer):
 
     def set_material(self, *args: Any, **kwargs: Any) -> None:
         self._app.set_material(*args, **kwargs)
+
+    def append_frame(self, *args: Any, **kwargs: Any) -> None:
+        self._app.append_frame(*args, **kwargs)
 
     def append_cylinder(self, *args: Any, **kwargs: Any) -> None:
         self._app.append_cylinder(*args, **kwargs)

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -1916,18 +1916,20 @@ class Viewer:
 
         :param name: Unique name. It must be a valid string identifier.
         :param shape: Desired shape, as a string, i.e. 'cone', 'box', 'sphere',
-                      'capsule', 'cylinder', or 'arrow'.
+                      'capsule', 'cylinder', 'frame', or 'arrow'.
         :param pose: Pose of the geometry on the scene, as a list of vectors
-                     (position [X, Y, Z], quaternion [X,  Y, Z, W]). `None`
-                     corresponds to world frame position and/or orientation.
-                     Optional: World frame by default.
+                     (position, orientation). The position must be the vector
+                     [X, Y, Z], while the orientation can be either a rotation
+                     matrix, or a quaternion [X, Y, Z, W]. `None` can be used
+                     to specify neutral frame position and/or orientation.
+                     Optional: Neutral position and orientation by default.
         :param scale: Size of the marker. Each principal axis of the geometry
                       are scaled separately.
         :param color: Color of the marker. It supports both RGBA codes as a
                       list of 4 floating-point values ranging from 0.0 and 1.0,
                       and a few named colors.
-                      Optional: robot's color by default if overridden,
-                      'red' otherwise.
+                      Optional: Robot's color by default if overridden,
+                                'white' otherwise, except for 'frame'.
         :param auto_refresh: Whether or not to refresh the scene after adding
                              the marker. Useful for adding a bunch of markers
                              and only refresh once. Note that the marker will
@@ -1961,9 +1963,10 @@ class Viewer:
             scale = np.full((3,), fill_value=float(scale))
         if color is None:
             color = self.robot_color
-        if color is None:
+        if color is None and shape != 'frame':
             color = 'white'
-        color = np.asarray(get_color_code(color))
+        if color is not None:
+            color = np.asarray(get_color_code(color))
 
         # Remove marker is one already exists and requested
         if name in self.markers.keys():
@@ -2266,8 +2269,10 @@ class Viewer:
                 else:
                     qx, qy, qz, qw = orientation
                 pose_dict[marker_name] = ((x, y, z), (qw, qx, qy, qz))
-                r, g, b, a = marker_data["color"]
-                material_dict[marker_name] = (2.0 * r, 2.0 * g, 2.0 * b, a)
+                color = marker_data["color"]
+                if color is not None:
+                    r, g, b, a = marker_data["color"]
+                    material_dict[marker_name] = (2.0 * r, 2.0 * g, 2.0 * b, a)
                 scale_dict[marker_name] = marker_data["scale"]
             self._gui.move_nodes(self._markers_group, pose_dict)
             self._gui.set_materials(self._markers_group, material_dict)

--- a/python/jiminy_pywrap/src/Constraints.cc
+++ b/python/jiminy_pywrap/src/Constraints.cc
@@ -169,8 +169,8 @@ namespace python
                                                      bp::return_internal_reference<>()),
                                                      &FixedFrameConstraint::setReferenceTransform)
                 .add_property("local_rotation", bp::make_function(&FixedFrameConstraint::getLocalFrame,
-                                                bp::return_value_policy<result_converter<false> >()),
-                                                &FixedFrameConstraint::setLocalFrame);
+                                                bp::return_value_policy<result_converter<false> >()))
+                .def("set_normal", &FixedFrameConstraint::setNormal);
 
             bp::class_<DistanceConstraint, bp::bases<AbstractConstraintBase>,
                        std::shared_ptr<DistanceConstraint>,


### PR DESCRIPTION
* [core] Move to next breakpoint if possible to avoid very small timesteps during integration.
* [core] PGS skip parameter update if irrelevant.
* [core] Fix timestep adjustment for fixed timestep euler explicit stepper.
* [core] Modify 'FixedFrameConstraint' to set ground normal instead of local rotation.
* [core] Improve contact solving by ordering 'FixedFrameConstraint' components by dependency.
* [core] Remove PGS's 'smart' index shuffling since it does not preserve dependency ordering.
* [python/viewer] Add 'frame' markers.
* [python/viewer] Support specifying marker orientation using rotation matrix.
* [python/viewer] Do not overwrite color for 'frame' marker by default.
* [gym/envs] Reduce KD gain for AkY joints of Atlas to prevent numerical instability.
* [gym/envs] Automatically detect relevant contact points for Atlas.
