### PR TITLE
[core] Contact handling improvements.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,7 +16,11 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        include:
+          - os: ubuntu-18.04
+            BUILD_TYPE: 'Release'
+          - os: ubuntu-20.04
+            BUILD_TYPE: 'Debug'
 
     defaults:
       run:
@@ -70,9 +74,7 @@ jobs:
               -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
               -DBoost_NO_SYSTEM_PATHS=OFF -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
-              -DCMAKE_BUILD_TYPE="Debug"
-        make install -j2
-        cmake -DCMAKE_BUILD_TYPE="Release" .
+              -DCMAKE_BUILD_TYPE="${{ matrix.BUILD_TYPE }}"
         make install -j2
 
     #####################################################################################
@@ -84,18 +86,21 @@ jobs:
         mkdir -p "$RootDir/examples/cpp/pip_extension/build"
         cd "$RootDir/examples/cpp/pip_extension/build"
         cmake "$RootDir/examples/cpp/pip_extension" -DCMAKE_INSTALL_PREFIX="$InstallDir" \
-              -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" -DCMAKE_BUILD_TYPE="Release"
+              -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" -DCMAKE_BUILD_TYPE="${{ matrix.BUILD_TYPE }}"
         make install
 
         "$InstallDir/bin/pip_double_pendulum"
 
-    - name: Run unit tests
+    - name: Run jiminy unit tests
       run: |
         "$RootDir/build/unit/unit"
 
         cd "$RootDir/unit_py"
         "${PYTHON_EXECUTABLE}" -m unittest discover -v
 
+    - name: Run gym_jiminy unit tests
+      if: matrix.BUILD_TYPE == 'Release'
+      run: |
         cd "$RootDir/python/gym_jiminy/unit_py"
         "${PYTHON_EXECUTABLE}" -m unittest discover -v
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -142,9 +142,9 @@ jobs:
         $JIMINY_LIB_DIR = (python -c "import os, jiminy_py ; print(os.path.dirname(jiminy_py.get_libraries()))")
         $env:Path += ";$JIMINY_LIB_DIR"
 
-        cmake "$RootDir/examples/cpp/pip_extension" -DCMAKE_INSTALL_PREFIX="$InstallDir" `
-              -DCMAKE_PREFIX_PATH="$InstallDir" -DPYTHON_REQUIRED_VERSION="${{ matrix.python-version }}" `
-              -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+        cmake "$RootDir/examples/cpp/pip_extension" -G "Visual Studio 16 2019" -T "v142" -DCMAKE_GENERATOR_PLATFORM=x64 `
+              -DCMAKE_INSTALL_PREFIX="$InstallDir" -DCMAKE_PREFIX_PATH="$InstallDir" `
+              -DPYTHON_REQUIRED_VERSION="${{ matrix.python-version }}"
         cmake --build . --target INSTALL --config "${env:BUILD_TYPE}"
 
         & "$InstallDir/bin/pip_double_pendulum.exe"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Set the build version
-set(BUILD_VERSION 1.7.5)
+set(BUILD_VERSION 1.7.6)
 
 # Set compatibility
 if(CMAKE_VERSION VERSION_GREATER "3.11.0")

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Beside a strong focus on performance to answer machine learning's need for runni
 
 ### Physics
 
-- Provide both classical phenomenological force-level spring-damper contact model and impulse-level LCP based on maximum energy dissipation principle.
+- Provide both classical phenomenological force-level spring-damper contact model and constraint solver based on maximum energy dissipation principle.
 - Support contact and collision with the ground, using either a fixed set of contact points or collision meshes and primitives.
 - Able to simulate multiple articulated systems simultaneously, interacting with each other, to support use cases such as multi-agent reinforcement learning or swarm robotics.
 - Support of compliant joints with force-based spring-damper dynamics, to model joint elasticity, a common phenomenon particularly in legged robotics.

--- a/core/include/jiminy/core/Constants.h
+++ b/core/include/jiminy/core/Constants.h
@@ -36,7 +36,6 @@ namespace jiminy
     extern float64_t const SIMULATION_MAX_TIMESTEP;
 
     extern uint32_t const PGS_MAX_ITERATIONS;
-    extern uint32_t const PGS_RANDOM_PERMUTATION_PERIOD;
     extern float64_t const PGS_MIN_REGULARIZER;
 }
 

--- a/core/include/jiminy/core/constraints/FixedFrameConstraint.h
+++ b/core/include/jiminy/core/constraints/FixedFrameConstraint.h
@@ -63,11 +63,13 @@ namespace jiminy
         std::string const frameName_;         ///< Name of the frame on which the constraint operates.
         frameIndex_t frameIdx_;               ///< Corresponding frame index.
         std::vector<uint32_t> dofsFixed_;     ///< Degrees of freedom to fix.
+        bool_t isFixedPositionXY_;            ///< Whether or not the frame is fixed for both X and Y translations
         pinocchio::SE3 transformRef_;         ///< Reference pose of the frame to enforce.
         vector3_t normal_;                    ///< Normal direction locally at the interface.
         matrix3_t rotationLocal_;             ///< Rotation matrix of the local frame in which to apply masking
         matrix6N_t frameJacobian_;            ///< Stores full frame jacobian in reference frame.
         pinocchio::Motion frameDrift_;        ///< Stores full frame drift in reference frame.
+        matrixN_t UiJt_;                      ///< Used to store intermediary computation to compute (J.Minv.Jt)_{i,i}
     };
 }
 

--- a/core/include/jiminy/core/constraints/FixedFrameConstraint.h
+++ b/core/include/jiminy/core/constraints/FixedFrameConstraint.h
@@ -50,7 +50,7 @@ namespace jiminy
         void setReferenceTransform(pinocchio::SE3 const & transformRef);
         pinocchio::SE3 const & getReferenceTransform(void) const;
 
-        void setLocalFrame(matrix3_t const & frameRot);
+        void setNormal(vector3_t const & normal);
         matrix3_t const & getLocalFrame(void) const;
 
         virtual hresult_t reset(vectorN_t const & q,
@@ -64,6 +64,7 @@ namespace jiminy
         frameIndex_t frameIdx_;               ///< Corresponding frame index.
         std::vector<uint32_t> dofsFixed_;     ///< Degrees of freedom to fix.
         pinocchio::SE3 transformRef_;         ///< Reference pose of the frame to enforce.
+        vector3_t normal_;                    ///< Normal direction locally at the interface.
         matrix3_t rotationLocal_;             ///< Rotation matrix of the local frame in which to apply masking
         matrix6N_t frameJacobian_;            ///< Stores full frame jacobian in reference frame.
         pinocchio::Motion frameDrift_;        ///< Stores full frame drift in reference frame.

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -115,9 +115,9 @@ namespace jiminy
         {
             configHolder_t config;
             config["solver"] = std::string("PGS");   // ["PGS",]
-            config["tolAbs"] = 1.0e-6;
-            config["tolRel"] = 1.0e-5;
-            config["regularization"] = 1.0e-3;     // Relative inverse damping wrt. diagonal of J.Minv.J.t. 0.0 to enforce the minimum absolute regularizer.
+            config["tolAbs"] = 1.0e-5;
+            config["tolRel"] = 1.0e-7;
+            config["regularization"] = 1.0e-3;       // Relative inverse damping wrt. diagonal of J.Minv.J.t. 0.0 to enforce the minimum absolute regularizer.
             config["stabilizationFreq"] = 20.0;      // [s-1]: 0.0 to disable
 
             return config;

--- a/core/include/jiminy/core/engine/System.h
+++ b/core/include/jiminy/core/engine/System.h
@@ -151,8 +151,7 @@ namespace jiminy
         std::vector<int32_t> boundJointsActiveDir;                     ///< Store the active "direction" of the bound (0 for lower, 1 for higher)
         forceVector_t contactFramesForces;                             ///< Contact forces for each contact frames in local frame
         vector_aligned_t<forceVector_t> collisionBodiesForces;         ///< Contact forces for each geometries of each collision bodies in local frame
-        matrixN_t jointJacobian;                                       ///< Buffer used for intermediary computation of `uAugmented`
-        vectorN_t uAugmented;                                          ///< Used to store the input effort plus the effect of external forces
+        matrixN_t jointJacobian;                                       ///< Buffer used for intermediary computation of `data.u`
         vectorN_t lo;                                                  ///< Lower bound of LCP problem
         vectorN_t hi;                                                  ///< Higher bound of LCP problem
         std::vector<std::vector<int32_t> > fIndices;                   ///< Used to indicate linear coupling between bounds of LCP and the solution (i.e. friction cone: - mu * F_z < F_x/F_y < mu * F_z)

--- a/core/include/jiminy/core/robot/AbstractSensor.h
+++ b/core/include/jiminy/core/robot/AbstractSensor.h
@@ -319,20 +319,22 @@ namespace jiminy
         /// \remark     This method is not intended to be called manually. The Robot to which the
         ///             sensor is added is taking care of it while updating the state of the sensors.
         ///
-        /// \param[in]  t       Current time.
-        /// \param[in]  q       Current configuration vector of the motor.
-        /// \param[in]  v       Current velocity vector of the motor.
-        /// \param[in]  a       Current acceleration vector of the motor.
-        /// \param[in]  uMotor  Current motor effort vector of the motor.
+        /// \param[in]  t          Current time.
+        /// \param[in]  q          Current configuration vector of the robot.
+        /// \param[in]  v          Current velocity vector of the robot.
+        /// \param[in]  a          Current acceleration vector of the robot.
+        /// \param[in]  uMotor     Current motor effort vector.
+        /// \param[in]  fExternal  std::vector of current external force vectors applied on the robot.
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        virtual hresult_t setAll(float64_t const & t,
-                                 vectorN_t const & q,
-                                 vectorN_t const & v,
-                                 vectorN_t const & a,
-                                 vectorN_t const & uMotor) = 0;
+        virtual hresult_t setAll(float64_t     const & t,
+                                 vectorN_t     const & q,
+                                 vectorN_t     const & v,
+                                 vectorN_t     const & a,
+                                 vectorN_t     const & uMotor,
+                                 forceVector_t const & fExternal) = 0;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         ///
@@ -341,20 +343,22 @@ namespace jiminy
         /// \details    It assumes that the internal state of the robot is consistent with the
         ///             input arguments.
         ///
-        /// \param[in]  t       Current time.
-        /// \param[in]  q       Current configuration vector of the robot.
-        /// \param[in]  v       Current velocity vector of the robot.
-        /// \param[in]  a       Current acceleration vector of the robot.
-        /// \param[in]  uMotor  Current motor effort vector of the robot.
+        /// \param[in]  t          Current time.
+        /// \param[in]  q          Current configuration vector of the robot.
+        /// \param[in]  v          Current velocity vector of the robot.
+        /// \param[in]  a          Current acceleration vector of the robot.
+        /// \param[in]  uMotor     Current motor effort vector.
+        /// \param[in]  fExternal  std::vector of current external force vectors applied on the robot.
         ///
         /// \return     Return code to determine whether the execution of the method was successful.
         ///
         ///////////////////////////////////////////////////////////////////////////////////////////////
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) = 0;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) = 0;
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         ///
@@ -458,11 +462,12 @@ namespace jiminy
         virtual Eigen::Ref<vectorN_t const> get(void) const override final;
 
     protected:
-        virtual hresult_t setAll(float64_t const & t,
-                                 vectorN_t const & q,
-                                 vectorN_t const & v,
-                                 vectorN_t const & a,
-                                 vectorN_t const & uMotor) override final;
+        virtual hresult_t setAll(float64_t     const & t,
+                                 vectorN_t     const & q,
+                                 vectorN_t     const & v,
+                                 vectorN_t     const & a,
+                                 vectorN_t     const & uMotor,
+                                 forceVector_t const & fExternal) override final;
         virtual Eigen::Ref<vectorN_t> get(void) override final;
         virtual Eigen::Ref<vectorN_t> data(void) override final;
 

--- a/core/include/jiminy/core/robot/AbstractSensor.tpp
+++ b/core/include/jiminy/core/robot/AbstractSensor.tpp
@@ -422,11 +422,12 @@ namespace jiminy
     }
 
     template<typename T>
-    hresult_t AbstractSensorTpl<T>::setAll(float64_t const & t,
-                                           vectorN_t const & q,
-                                           vectorN_t const & v,
-                                           vectorN_t const & a,
-                                           vectorN_t const & uMotor)
+    hresult_t AbstractSensorTpl<T>::setAll(float64_t     const & t,
+                                           vectorN_t     const & q,
+                                           vectorN_t     const & v,
+                                           vectorN_t     const & a,
+                                           vectorN_t     const & uMotor,
+                                           forceVector_t const & fExternal)
     {
         hresult_t returnCode = hresult_t::SUCCESS;
 
@@ -498,7 +499,7 @@ namespace jiminy
         {
             if (returnCode == hresult_t::SUCCESS)
             {
-                returnCode = sensor->set(t, q, v, a, uMotor);
+                returnCode = sensor->set(t, q, v, a, uMotor, fExternal);
             }
         }
 

--- a/core/include/jiminy/core/robot/BasicSensors.h
+++ b/core/include/jiminy/core/robot/BasicSensors.h
@@ -29,11 +29,12 @@ namespace jiminy
         frameIndex_t const & getFrameIdx(void) const;
 
     private:
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) final override;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) final override;
         virtual void skewMeasurement(void) final override;
 
     private:
@@ -58,11 +59,12 @@ namespace jiminy
         frameIndex_t const & getFrameIdx(void) const;
 
     private:
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) final override;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) final override;
 
     private:
         std::string frameName_;
@@ -86,16 +88,18 @@ namespace jiminy
         jointIndex_t getJointIdx(void) const;
 
     private:
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) final override;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) final override;
 
     private:
         std::string frameName_;
         frameIndex_t frameIdx_;
         jointIndex_t parentJointIdx_;
+        pinocchio::Force f_;
     };
 
     class EncoderSensor : public AbstractSensorTpl<EncoderSensor>
@@ -115,11 +119,12 @@ namespace jiminy
         joint_t const & getJointType(void) const;
 
     private:
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) final override;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) final override;
 
     private:
         std::string jointName_;
@@ -143,11 +148,12 @@ namespace jiminy
         std::size_t const & getMotorIdx(void) const;
 
     private:
-        virtual hresult_t set(float64_t const & t,
-                              vectorN_t const & q,
-                              vectorN_t const & v,
-                              vectorN_t const & a,
-                              vectorN_t const & uMotor) final override;
+        virtual hresult_t set(float64_t     const & t,
+                              vectorN_t     const & q,
+                              vectorN_t     const & v,
+                              vectorN_t     const & a,
+                              vectorN_t     const & uMotor,
+                              forceVector_t const & fExternal) final override;
 
     private:
         std::string motorName_;

--- a/core/include/jiminy/core/robot/Model.h
+++ b/core/include/jiminy/core/robot/Model.h
@@ -405,7 +405,7 @@ namespace jiminy
         pinocchio::GeometryModel collisionModel_;
         pinocchio::GeometryModel visualModelOrig_;
         pinocchio::GeometryModel visualModel_;
-        pinocchio::Data pncDataRigidOrig_;
+        pinocchio::Data pncDataOrig_;
         mutable pinocchio::Data pncData_;
         mutable std::unique_ptr<pinocchio::GeometryData> collisionData_;  // Using smart ptr to avoid having to initialize it with an empty GeometryModel, which causes Pinocchio segfault at least up to v2.5.6
         std::unique_ptr<modelOptions_t const> mdlOptions_;

--- a/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
+++ b/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
@@ -471,11 +471,11 @@ namespace pinocchio_overload
                                               pinocchio::Data & data,
                                               Eigen::MatrixBase<TangentVectorType> const & a)
     {
-        typedef ForwardKinematicsAccelerationStep<TangentVectorType> Pass1;
+        typedef ForwardKinematicsAccelerationStep<TangentVectorType> Pass;
         data.a[0].setZero();
         for (int32_t i = 1; i < model.njoints; ++i)
         {
-            Pass1::run(model.joints[i], data.joints[i], typename Pass1::ArgsType(model, data, a));
+            Pass::run(model.joints[i], data.joints[i], typename Pass::ArgsType(model, data, a));
         }
     }
 

--- a/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
+++ b/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
@@ -454,7 +454,10 @@ namespace pinocchio_overload
             jointIndex_t const & i = jmodel.id();
             jointIndex_t const & parent = model.parents[i];
             data.a[i]  = jdata.S() * jmodel.jointVelocitySelector(a) + jdata.c() + (data.v[i] ^ jdata.v());
-            data.a[i] += data.liMi[i].actInv(data.a[parent]);
+            if (parent > 0)
+            {
+                data.a[i] += data.liMi[i].actInv(data.a[parent]);
+            }
         }
     };
 

--- a/core/include/jiminy/core/robot/Robot.h
+++ b/core/include/jiminy/core/robot/Robot.h
@@ -72,11 +72,12 @@ namespace jiminy
                                   vectorN_t const & command);
         vectorN_t const & getMotorsEfforts(void) const;
         float64_t const & getMotorEffort(std::string const & motorName) const;
-        void setSensorsData(float64_t const & t,
-                            vectorN_t const & q,
-                            vectorN_t const & v,
-                            vectorN_t const & a,
-                            vectorN_t const & uMotor);
+        void setSensorsData(float64_t     const & t,
+                            vectorN_t     const & q,
+                            vectorN_t     const & v,
+                            vectorN_t     const & a,
+                            vectorN_t     const & uMotor,
+                            forceVector_t const & fExternal);
 
         sensorsDataMap_t getSensorsData(void) const;
         Eigen::Ref<vectorN_t const> getSensorData(std::string const & sensorType,

--- a/core/include/jiminy/core/solver/LCPSolvers.h
+++ b/core/include/jiminy/core/solver/LCPSolvers.h
@@ -12,13 +12,13 @@ namespace jiminy
         AbstractLCPSolver(void) = default;
         virtual ~AbstractLCPSolver(void) = default;
 
-        /// \brief Compute the solution of the Linear Complementary Problem:
+        /// \brief Compute the solution of the Nonlinear Complementary Problem:
         ///        A x + b = w,
         ///        s.t. (w[i] > 0 and x[i] = 0) or (w[i] = 0 and x[i] > 0
         ///
-        ///        using boxed bounds lo < x < hi instead of 0 < x:
+        ///        for non-linear boxed bounds lo(x) < x < hi(x):
         ///        s.t. if fIndices[i].size() == 0, lo[i] < x[i] < hi[i]
-        ///             else, sqrt(x[i] ** 2 + sum_{j>=1}(x[fIndices[i][j]] ** 2)) < hi[i] * abs(x[fIndices[i][0]])
+        ///             else, sqrt(x[i] ** 2 + sum_{j>=1}(x[fIndices[i][j]] ** 2)) < hi[i] * max(0.0, x[fIndices[i][0]])
         ///
         /// The result x will be stored in data.lambda_c.
         virtual bool_t BoxedForwardDynamics(pinocchio::Model const & model,

--- a/core/include/jiminy/core/solver/LCPSolvers.h
+++ b/core/include/jiminy/core/solver/LCPSolvers.h
@@ -72,6 +72,8 @@ namespace jiminy
         std::vector<uint32_t> indices_;
         uint32_t lastShuffle_;
         vectorN_t b_;
+        vectorN_t y_;
+        vectorN_t yPrev_;
     };
 
 

--- a/core/include/jiminy/core/solver/LCPSolvers.h
+++ b/core/include/jiminy/core/solver/LCPSolvers.h
@@ -36,7 +36,6 @@ namespace jiminy
     {
     public:
         PGSSolver(uint32_t const & maxIter,
-                  uint32_t const & randomPermutationPeriod,
                   float64_t const & tolAbs,
                   float64_t const & tolRel);
 
@@ -51,12 +50,12 @@ namespace jiminy
                                             std::vector<std::vector<int32_t> > const & fIndices) override final;
 
     private:
-        bool_t ProjectedGaussSeidelIter(matrixN_t const & A,
-                                        vectorN_t const & b,
-                                        vectorN_t const & lo,
-                                        vectorN_t const & hi,
-                                        std::vector<std::vector<int32_t> > const & fIndices,
-                                        vectorN_t & x);
+        void ProjectedGaussSeidelIter(matrixN_t const & A,
+                                      vectorN_t const & b,
+                                      vectorN_t const & lo,
+                                      vectorN_t const & hi,
+                                      std::vector<std::vector<int32_t> > const & fIndices,
+                                      vectorN_t & x);
         bool_t ProjectedGaussSeidelSolver(matrixN_t & A,
                                           vectorN_t & b,
                                           vectorN_t const & lo,
@@ -66,14 +65,13 @@ namespace jiminy
 
     private:
         uint32_t maxIter_;
-        uint32_t randomPermutationPeriod_;
         float64_t tolAbs_;
         float64_t tolRel_;
-        std::vector<uint32_t> indices_;
-        uint32_t lastShuffle_;
         vectorN_t b_;
+        vectorN_t xPrev_;
         vectorN_t y_;
         vectorN_t yPrev_;
+        vectorN_t dy_;
     };
 
 

--- a/core/src/Constants.cc
+++ b/core/src/Constants.cc
@@ -20,6 +20,5 @@ namespace jiminy
     float64_t const SIMULATION_MAX_TIMESTEP = 0.02;
 
     uint32_t const PGS_MAX_ITERATIONS = 100U;
-    uint32_t const PGS_RANDOM_PERMUTATION_PERIOD = 0U;  // 0 to disable
     float64_t const PGS_MIN_REGULARIZER = 1.0e-11;
 }

--- a/core/src/Constants.cc
+++ b/core/src/Constants.cc
@@ -21,5 +21,5 @@ namespace jiminy
 
     uint32_t const PGS_MAX_ITERATIONS = 100U;
     uint32_t const PGS_RANDOM_PERMUTATION_PERIOD = 0U;  // 0 to disable
-    float64_t const PGS_MIN_REGULARIZER = 1.0e-12;
+    float64_t const PGS_MIN_REGULARIZER = 1.0e-11;
 }

--- a/core/src/constraints/AbstractConstraint.cc
+++ b/core/src/constraints/AbstractConstraint.cc
@@ -59,12 +59,12 @@ namespace jiminy
 
     void AbstractConstraintBase::enable(void)
     {
+        lambda_.setZero();
         isEnabled_ = true;
     }
 
     void AbstractConstraintBase::disable(void)
     {
-        lambda_.setZero();
         isEnabled_ = false;
     }
 

--- a/core/src/constraints/FixedFrameConstraint.cc
+++ b/core/src/constraints/FixedFrameConstraint.cc
@@ -18,13 +18,14 @@ namespace jiminy
     frameIdx_(0),
     dofsFixed_(),
     transformRef_(),
-    rotationLocal_(),
+    normal_(),
+    rotationLocal_(matrix3_t::Identity()),
     frameJacobian_(),
     frameDrift_()
     {
         dofsFixed_.resize(static_cast<std::size_t>(maskFixed.cast<int32_t>().array().sum()));
         uint32_t dofIndex = 0;
-        for (uint32_t i=0; i < 6; ++i)
+        for (uint32_t i : std::vector<uint32_t>{{3, 4, 5, 0, 1, 2}})
         {
             if (maskFixed[i])
             {
@@ -64,9 +65,12 @@ namespace jiminy
         return transformRef_;
     }
 
-    void FixedFrameConstraint::setLocalFrame(matrix3_t const & frameRot)
+    void FixedFrameConstraint::setNormal(vector3_t const & normal)
     {
-        rotationLocal_ = frameRot;
+        normal_ = normal;
+        rotationLocal_.col(2) = normal_;
+        rotationLocal_.col(1) = normal_.cross(vector3_t::UnitX()).normalized();
+        rotationLocal_.col(0) = rotationLocal_.col(1).cross(rotationLocal_.col(2));
     }
 
     matrix3_t const & FixedFrameConstraint::getLocalFrame(void) const

--- a/core/src/constraints/FixedFrameConstraint.cc
+++ b/core/src/constraints/FixedFrameConstraint.cc
@@ -156,10 +156,11 @@ namespace jiminy
                                            pinocchio::LOCAL_WORLD_ALIGNED);
 
         // Add Baumgarte stabilization to drift in world frame
-        vector3_t const deltaPosition = model->pncData_.oMf[frameIdx_].translation() - transformRef_.translation();
-        matrix3_t const deltaRotation = transformRef_.rotation().transpose() * model->pncData_.oMf[frameIdx_].rotation();
+        pinocchio::SE3 const & framePose = model->pncData_.oMf[frameIdx_];
+        vector3_t const deltaPosition = framePose.translation() - transformRef_.translation();
+        matrix3_t const deltaRotation = transformRef_.rotation().transpose() * framePose.rotation();
         frameDrift_.linear() += kp_ * deltaPosition;
-        frameDrift_.angular() += kp_ * pinocchio::log3(deltaRotation);
+        frameDrift_.angular() += kp_ * framePose.rotation() * pinocchio::log3(deltaRotation);
         pinocchio::Motion const velocity = getFrameVelocity(model->pncModel_,
                                                             model->pncData_,
                                                             frameIdx_,

--- a/core/src/constraints/FixedFrameConstraint.cc
+++ b/core/src/constraints/FixedFrameConstraint.cc
@@ -25,7 +25,7 @@ namespace jiminy
     {
         dofsFixed_.resize(static_cast<std::size_t>(maskFixed.cast<int32_t>().array().sum()));
         uint32_t dofIndex = 0;
-        for (uint32_t i : std::vector<uint32_t>{{3, 4, 5, 0, 1, 2}})
+        for (uint32_t i : std::vector<uint32_t>{{2, 1, 0, 3, 4, 5}})
         {
             if (maskFixed[i])
             {

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -3744,15 +3744,16 @@ namespace jiminy
                             return;
                         }
 
-                        // Enforce tangential friction pyramid and torsional friction
-                        hi[constraintIdx] = contactOptions.friction;      // Friction along x-axis
-                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 2)};
-                        hi[constraintIdx + 1] = contactOptions.friction;  // Friction along y-axis
-                        fIndices[constraintIdx + 1] = {static_cast<int32_t>(constraintIdx + 2)};
-                        hi[constraintIdx + 3] = contactOptions.torsion;   // Friction around z-axis
+                        // Friction cone in tangential plane
+                        hi[constraintIdx] = contactOptions.friction;
+                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 2),
+                                                   static_cast<int32_t>(constraintIdx + 1)};
+
+                        // Torsional friction around normal axis
+                        hi[constraintIdx + 3] = contactOptions.torsion;
                         fIndices[constraintIdx + 3] = {static_cast<int32_t>(constraintIdx + 2)};
 
-                        // Vertical force cannot be negative
+                        // Non-penetration normal force
                         lo[constraintIdx + 2] = 0.0;
 
                         constraintIdx += constraint->getDim();

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -887,7 +887,6 @@ namespace jiminy
         {
             constraintSolver_ = std::make_unique<PGSSolver>(
                 PGS_MAX_ITERATIONS,
-                PGS_RANDOM_PERMUTATION_PERIOD,
                 engineOptions_->constraints.tolAbs,
                 engineOptions_->constraints.tolRel);
         }
@@ -3755,16 +3754,16 @@ namespace jiminy
                         }
 
                         // Torsional friction around normal axis
-                        hi[constraintIdx] = contactOptions.torsion;
-                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 3)};
+                        hi[constraintIdx + 3] = contactOptions.torsion;
+                        fIndices[constraintIdx + 3] = {static_cast<int32_t>(constraintIdx)};
 
                         // Friction cone in tangential plane
-                        hi[constraintIdx + 1] = contactOptions.friction;
-                        fIndices[constraintIdx + 1] = {static_cast<int32_t>(constraintIdx + 3),
-                                                       static_cast<int32_t>(constraintIdx + 2)};
+                        hi[constraintIdx + 2] = contactOptions.friction;
+                        fIndices[constraintIdx + 2] = {static_cast<int32_t>(constraintIdx),
+                                                       static_cast<int32_t>(constraintIdx + 1)};
 
                         // Non-penetration normal force
-                        lo[constraintIdx + 3] = 0.0;
+                        lo[constraintIdx] = 0.0;
 
                         constraintIdx += constraint->getDim();
                     });
@@ -3853,8 +3852,8 @@ namespace jiminy
 
                 // Extract force in local reference-frame-aligned from lagrangian multipliers
                 pinocchio::Force fextInLocal(
-                    frameConstraint.lambda_.tail<3>(),
-                    frameConstraint.lambda_[0] * vector3_t::UnitZ());
+                    frameConstraint.lambda_.head<3>().reverse(),
+                    frameConstraint.lambda_[3] * vector3_t::UnitZ());
 
                 // Compute force in local world aligned frame
                 matrix3_t const & rotationLocal = frameConstraint.getLocalFrame();
@@ -3888,8 +3887,8 @@ namespace jiminy
 
                     // Extract force in world frame from lagrangian multipliers
                     pinocchio::Force fextInLocal(
-                        frameConstraint.lambda_.tail<3>(),
-                        frameConstraint.lambda_[0] * vector3_t::UnitZ());
+                        frameConstraint.lambda_.head<3>().reverse(),
+                        frameConstraint.lambda_[3] * vector3_t::UnitZ());
 
                     // Compute force in world frame
                     matrix3_t const & rotationLocal = frameConstraint.getLocalFrame();

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -3743,11 +3743,9 @@ namespace jiminy
 
                         // Enforce tangential friction pyramid and torsional friction
                         hi[constraintIdx] = contactOptions.friction;      // Friction along x-axis
-                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 2),
-                                                   static_cast<int32_t>(constraintIdx + 1)};
+                        fIndices[constraintIdx] = {static_cast<int32_t>(constraintIdx + 2)};
                         hi[constraintIdx + 1] = contactOptions.friction;  // Friction along y-axis
-                        fIndices[constraintIdx + 1] = {static_cast<int32_t>(constraintIdx + 2),
-                                                       static_cast<int32_t>(constraintIdx)};
+                        fIndices[constraintIdx + 1] = {static_cast<int32_t>(constraintIdx + 2)};
                         hi[constraintIdx + 3] = contactOptions.torsion;   // Friction around z-axis
                         fIndices[constraintIdx + 3] = {static_cast<int32_t>(constraintIdx + 2)};
 

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -3785,9 +3785,6 @@ namespace jiminy
             // Compute non-linear effects
             pinocchio::nonLinearEffects(model, data, q, v);
 
-            // Compute inertia matrix, adding rotor inertia
-            pinocchio_overload::crba(model, data, q);
-
             // Call forward dynamics
             constraintSolver_->BoxedForwardDynamics(model,
                                                     data,

--- a/core/src/engine/System.cc
+++ b/core/src/engine/System.cc
@@ -175,7 +175,6 @@ namespace jiminy
     contactFramesForces(),
     collisionBodiesForces(),
     jointJacobian(),
-    uAugmented(),
     lo(),
     hi(),
     fIndices(),

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -802,20 +802,17 @@ namespace jiminy
             return hresult_t::ERROR_BAD_INPUT;
         }
 
-        // Remove the list of frames from the set of contact frames
+        /* Remove the constraint associated with contact frame, then
+           remove the list of frames from the set of contact frames. */
         if (!frameNames.empty())
         {
+            removeConstraints(frameNames, constraintsHolderType_t::CONTACT_FRAMES);  // It cannot fail at this point
             eraseVector(contactFramesNames_, frameNames);
         }
         else
         {
+            removeConstraints(contactFramesNames_, constraintsHolderType_t::CONTACT_FRAMES);
             contactFramesNames_.clear();
-        }
-
-        // Remove constraint associated with contact frame, disable by default
-        for (std::string const & frameName : frameNames)
-        {
-            removeConstraint(frameName, constraintsHolderType_t::CONTACT_FRAMES);  // It cannot fail at this point
         }
 
         // Refresh proxies associated with contacts and constraints

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -195,7 +195,7 @@ namespace jiminy
     collisionModel_(),
     visualModelOrig_(),
     visualModel_(),
-    pncDataRigidOrig_(),
+    pncDataOrig_(),
     pncData_(),
     collisionData_(nullptr),
     mdlOptions_(nullptr),
@@ -292,17 +292,17 @@ namespace jiminy
             }
 
             // Backup the original model and data
-            pncDataRigidOrig_ = pinocchio::Data(pncModelOrig_);
+            pncDataOrig_ = pinocchio::Data(pncModelOrig_);
 
             // Initialize Pinocchio data internal state, including basic
             // attributes such as the mass of each body.
             pinocchio::forwardKinematics(pncModelOrig_,
-                                         pncDataRigidOrig_,
+                                         pncDataOrig_,
                                          pinocchio::neutral(pncModelOrig_),
                                          vectorN_t::Zero(pncModelOrig_.nv));
-            pinocchio::updateFramePlacements(pncModelOrig_, pncDataRigidOrig_);
+            pinocchio::updateFramePlacements(pncModelOrig_, pncDataOrig_);
             pinocchio::centerOfMass(pncModelOrig_,
-                                    pncDataRigidOrig_,
+                                    pncDataOrig_,
                                     pinocchio::neutral(pncModelOrig_));
 
             /* Get the list of joint names of the rigid model and remove the 'universe'
@@ -425,7 +425,7 @@ namespace jiminy
                 pinocchio::SE3 const jointFramePlacement = parentFramePlacement.act(framePlacement);
                 pinocchio::Frame const frame(frameName, parentJointId, parentFrameId, jointFramePlacement, frameType);
                 pncModelOrig_.addFrame(frame);
-                pncDataRigidOrig_ = pinocchio::Data(pncModelOrig_);
+                pncDataOrig_ = pinocchio::Data(pncModelOrig_);
             }
 
             // Add the frame to the the original flexible model
@@ -498,7 +498,7 @@ namespace jiminy
             }
 
             // Regenerate rigid data
-            pncDataRigidOrig_ = pinocchio::Data(pncModelOrig_);
+            pncDataOrig_ = pinocchio::Data(pncModelOrig_);
 
             // One must reset the model after removing a frame
             reset();

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -1193,6 +1193,13 @@ namespace jiminy
         // Compute joint jacobian manually since not done by engine for efficiency
         pinocchio::computeJointJacobians(pncModel_, pncData_);
 
+        // Compute inertia matrix, taking into account armature
+        pinocchio_overload::crba(pncModel_, pncData_, q);
+
+        // Compute the mass matrix decomposition, since it may be used for
+        // constraint stabilization.
+        pinocchio::cholesky::decompose(pncModel_, pncData_);
+
         /* Computing forward kinematics without acceleration to get the drift.
            Note that it will alter the actual joints spatial accelerations, so
            it is necessary to do a backup first to restore it later on. */

--- a/core/src/robot/Robot.cc
+++ b/core/src/robot/Robot.cc
@@ -1216,11 +1216,12 @@ namespace jiminy
         return motorEffortEmpty;
     }
 
-    void Robot::setSensorsData(float64_t const & t,
-                               vectorN_t const & q,
-                               vectorN_t const & v,
-                               vectorN_t const & a,
-                               vectorN_t const & uMotor)
+    void Robot::setSensorsData(float64_t     const & t,
+                               vectorN_t     const & q,
+                               vectorN_t     const & v,
+                               vectorN_t     const & a,
+                               vectorN_t     const & uMotor,
+                               forceVector_t const & fExternal)
     {
         /* Note that it is assumed that the kinematic quantities have been
            updated previously to be consistent with (q, v, a, u). If not,
@@ -1231,7 +1232,7 @@ namespace jiminy
         {
             if (!sensorGroup.second.empty())
             {
-                (*sensorGroup.second.begin())->setAll(t, q, v, a, uMotor);
+                (*sensorGroup.second.begin())->setAll(t, q, v, a, uMotor, fExternal);
             }
         }
     }

--- a/core/src/solver/LCPSolvers.cc
+++ b/core/src/solver/LCPSolvers.cc
@@ -63,23 +63,37 @@ namespace jiminy
             }
             else
             {
-                float64_t thr;
                 float64_t f = x[fIdx[0]];
-                if (fSize == 1)
+                float64_t thr = hi[i] * f;
+                if (thr > EPS)
                 {
-                    thr = hi[i] * std::abs(f);
+                    if (fSize == 1)
+                    {
+                        e = clamp(e, -thr, thr);
+                    }
+                    else
+                    {
+                        thr *= thr;
+                        for (auto fIt = fIdx.begin() + 1; fIt != fIdx.end(); ++fIt)
+                        {
+                            f = x[*fIt];
+                            thr -= f * f;
+                        }
+                        if (thr > EPS)
+                        {
+                            thr = std::sqrt(thr);
+                            e = clamp(e, -thr, thr);
+                        }
+                        else
+                        {
+                            e = 0.0;
+                        }
+                    }
                 }
                 else
                 {
-                    thr = hi[i] * f * f;
-                    for (auto fIt = fIdx.begin() + 1; fIt != fIdx.end(); ++fIt)
-                    {
-                        f = x[*fIt];
-                        thr -= f * f;
-                    }
-                    thr = std::sqrt(std::max(0.0, thr));
+                    e = 0.0;
                 }
-                e = clamp(e, -thr, thr);
             }
 
             // Check if still possible to terminate after complete update

--- a/core/src/solver/LCPSolvers.cc
+++ b/core/src/solver/LCPSolvers.cc
@@ -22,7 +22,9 @@ namespace jiminy
     tolRel_(tolRel),
     indices_(),
     lastShuffle_(0U),
-    b_()
+    b_(),
+    y_(),
+    yPrev_()
     {
         // Empty on purpose.
     }
@@ -34,8 +36,6 @@ namespace jiminy
                                                std::vector<std::vector<int32_t> > const & fIndices,
                                                vectorN_t & x)
     {
-        bool_t isSuccess = true;
-
         // Shuffle coefficient update order to break any repeating cycles
         if (randomPermutationPeriod_ > 0 && lastShuffle_ > randomPermutationPeriod_)
         {
@@ -44,12 +44,14 @@ namespace jiminy
         }
         ++lastShuffle_;
 
+        // Backup previous solution
+        yPrev_.noalias() = A * x;
+
         // Update every coefficients sequentially
         for (uint32_t const & i : indices_)
         {
             // Extract single coefficient
             float64_t & e = x[i];
-            float64_t const ePrev = e;
 
             // Update a single coefficient
             e += (b[i] - A.col(i).dot(x)) / A(i, i);
@@ -95,10 +97,14 @@ namespace jiminy
                     e = 0.0;
                 }
             }
-
-            // Check if still possible to terminate after complete update
-            isSuccess = isSuccess && (std::abs(e - ePrev) < tolAbs_ || std::abs((e - ePrev) / e) < tolRel_);
         }
+
+        // Check if terminate conditions are satisfied
+        y_.noalias() = A * x;
+        bool_t isSuccess = (
+            (y_ - yPrev_).array().abs() < tolAbs_ ||
+            ((y_ - yPrev_).array() / y_.array()).abs() < tolRel_
+        ).all();
 
         return isSuccess;
     }

--- a/core/src/stepper/AbstractRungeKuttaStepper.cc
+++ b/core/src/stepper/AbstractRungeKuttaStepper.cc
@@ -79,10 +79,7 @@ namespace jiminy
                                                  state_t   const & /* solution */,
                                                  float64_t       & dt)
     {
-        /* Fixed-step by default, which never fails. By default INF is retuned
-           in case of fixed time step, so that the engine will always try to
-           perform the latest timestep possible, or stop to the next breakpoint
-           otherwise. */
+        // Fixed-step by default, which never fails
         dt = INF;
         return true;
     }

--- a/core/src/stepper/EulerExplicitStepper.cc
+++ b/core/src/stepper/EulerExplicitStepper.cc
@@ -19,6 +19,11 @@ namespace jiminy
         stateDerivative = f(t, state);
         state.sumInPlace(stateDerivative, dt);
 
+        /* By default INF is retuned in case of fixed time step, so that the
+           engine will always try to perform the latest timestep possible,
+           or stop to the next breakpoint otherwise. */
+        dt = INF;
+
         // Scheme never considers failure.
         return true;
     }

--- a/core/src/telemetry/TelemetryData.cc
+++ b/core/src/telemetry/TelemetryData.cc
@@ -140,7 +140,7 @@ namespace jiminy
         floatsHeader_->isRegisteringAvailable = false;
 
         header.clear();
-        header.reserve(64 * 1024);
+        header.reserve(64U * 1024U);
 
         // Record format version
         header.resize(sizeof(int32_t));
@@ -185,6 +185,7 @@ namespace jiminy
 
         // Start data section
         header.insert(header.end(), START_DATA.data(), START_DATA.data() + START_DATA.size());
+        header.push_back('\0');
     }
 
     void TelemetryData::getData(char_t  const * & intAddrOut,

--- a/core/src/telemetry/TelemetryRecorder.cc
+++ b/core/src/telemetry/TelemetryRecorder.cc
@@ -268,12 +268,6 @@ namespace jiminy
                         {
                             break;
                         }
-                        if (posHeader + fieldHeader.size() > headerCharBuffer.size())
-                        {
-                            fieldHeader = std::string(pHeader + posHeader, headerCharBuffer.size() - posHeader);
-                            logData.header.push_back(std::move(fieldHeader));
-                            break;
-                        }
                     }
                     isReadingHeaderDone = true;
                 }

--- a/core/src/utilities/Json.cc
+++ b/core/src/utilities/Json.cc
@@ -56,7 +56,7 @@ namespace jiminy
     template<>
     Json::Value convertToJson<configHolder_t>(configHolder_t const & value)
     {
-        Json::Value root;
+        Json::Value root{Json::objectValue};
         AppendBoostVariantToJson visitor(root);
         for (auto const & option : value)
         {

--- a/core/src/utilities/Pinocchio.cc
+++ b/core/src/utilities/Pinocchio.cc
@@ -640,9 +640,14 @@ namespace jiminy
             int32_t incrementalNv = 0;
             for (std::size_t i = 1; i < modelInOut.joints.size(); ++i)
             {
-                modelInOut.joints[i].setIndexes(i, incrementalNq, incrementalNv);
-                incrementalNq += modelInOut.joints[i].nq();
-                incrementalNv += modelInOut.joints[i].nv();
+                pinocchio::JointModel & jmodel = modelInOut.joints[i];
+                jmodel.setIndexes(i, incrementalNq, incrementalNv);
+                incrementalNq += jmodel.nq();
+                incrementalNv += jmodel.nv();
+                modelInOut.nqs[i] = jmodel.nq();
+                modelInOut.idx_qs[i] = jmodel.idx_q();
+                modelInOut.nvs[i] = jmodel.nv();
+                modelInOut.idx_vs[i] = jmodel.idx_v();
             }
         }
     }
@@ -782,9 +787,9 @@ namespace jiminy
 
         // Create flexible joint
         jointIndex_t const newJointIdx = modelInOut.addJoint(parentJointIdx,
-                                                           JointModelSpherical(),
-                                                           frame.placement,
-                                                           newJointNameIn);
+                                                             JointModelSpherical(),
+                                                             frame.placement,
+                                                             newJointNameIn);
         modelInOut.appendBodyToJoint(newJointIdx, childBodyInertiaIn, SE3::Identity());
 
         // Add new joint to frame list

--- a/data/bipedal_robots/atlas/atlas_v4_options.toml
+++ b/data/bipedal_robots/atlas/atlas_v4_options.toml
@@ -10,13 +10,15 @@ randomSeed = 0
 
 # ============== Ground dynamics ===============
 
-[engine.contacts]
-model = "impulse"
+[engine.constraints]
 solver = "PGS"
-tolAbs = 1.0e-4
-tolRel = 1.0e-3
+tolAbs = 1.0e-6
+tolRel = 1.0e-5
 regularization = 2.0e-3
 stabilizationFreq = 20.0
+
+[engine.contacts]
+model = "constraint"
 transitionEps = 5.0e-3
 friction = 1.0
 

--- a/data/bipedal_robots/atlas/atlas_v4_options.toml
+++ b/data/bipedal_robots/atlas/atlas_v4_options.toml
@@ -12,8 +12,8 @@ randomSeed = 0
 
 [engine.constraints]
 solver = "PGS"
-tolAbs = 1.0e-6
-tolRel = 1.0e-5
+tolAbs = 1.0e-5
+tolRel = 1.0e-7
 regularization = 2.0e-3
 stabilizationFreq = 20.0
 

--- a/data/bipedal_robots/cassie/cassie_options.toml
+++ b/data/bipedal_robots/cassie/cassie_options.toml
@@ -10,13 +10,15 @@ randomSeed = 0
 
 # ============== Ground dynamics ===============
 
-[engine.contacts]
-model = "impulse"
+[engine.constraints]
 solver = "PGS"
-tolAbs = 1.0e-4
-tolRel = 1.0e-3
+tolAbs = 1.0e-6
+tolRel = 1.0e-5
 regularization = 2.0e-3
 stabilizationFreq = 20.0
+
+[engine.contacts]
+model = "constraint"
 transitionEps = 2.0e-3
 friction = 0.5
 

--- a/data/bipedal_robots/cassie/cassie_options.toml
+++ b/data/bipedal_robots/cassie/cassie_options.toml
@@ -12,8 +12,8 @@ randomSeed = 0
 
 [engine.constraints]
 solver = "PGS"
-tolAbs = 1.0e-6
-tolRel = 1.0e-5
+tolAbs = 1.0e-5
+tolRel = 1.0e-7
 regularization = 2.0e-3
 stabilizationFreq = 20.0
 

--- a/data/toys_models/ant/ant_options.toml
+++ b/data/toys_models/ant/ant_options.toml
@@ -10,13 +10,15 @@ randomSeed = 0
 
 # ============== Contact dynamics ===============
 
-[engine.contacts]
-model = "impulse"
+[engine.constraints]
 solver = "PGS"
 tolAbs = 1.0e-4
 tolRel = 1.0e-3
 regularization = 1.0e-1
 stabilizationFreq = 5.0
+
+[engine.contacts]
+model = "constraint"
 transitionEps = 1.0e-2
 friction = 1.0
 

--- a/examples/cpp/double_pendulum/double_pendulum.cc
+++ b/examples/cpp/double_pendulum/double_pendulum.cc
@@ -110,8 +110,8 @@ int main(int /* argc */, char_t * /* argv */[])
     boost::get<std::string>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("model")) = std::string("spring_damper");
     boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("stiffness")) = 1.0e6;
     boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("damping")) = 2000.0;
-    boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("transitionEps")) = 0.001;
     boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("friction")) = 5.0;
+    boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("transitionEps")) = 0.001;
     boost::get<float64_t>(boost::get<configHolder_t>(simuOptions.at("contacts")).at("transitionVelocity")) = 0.01;
     engine->setOptions(simuOptions);
     engine->initialize(robot, controller, callback);

--- a/examples/python/box_uneven_ground_impulse_contact.py
+++ b/examples/python/box_uneven_ground_impulse_contact.py
@@ -25,9 +25,9 @@ urdf_path = f"{os.environ['HOME']}/wdc_workspace/src/jiminy/unit_py/data/box_col
 env = BaseJiminyEnv(Simulator.build(
     urdf_path, has_freeflyer=True), step_dt=0.01)
 
-# Enable impulse contact model
+# Enable constraint contact model
 engine_options = env.engine.get_options()
-engine_options['contacts']['model'] = 'impulse'
+engine_options['contacts']['model'] = 'constraint'
 env.engine.set_options(engine_options)
 
 # Generate random ground profile

--- a/examples/python/box_uneven_ground_impulse_contact.py
+++ b/examples/python/box_uneven_ground_impulse_contact.py
@@ -7,6 +7,10 @@ from jiminy_py.simulator import Simulator
 from jiminy_py.core import random_tile_ground, sum_heightmap, merge_heightmap
 from gym_jiminy.common.envs import BaseJiminyEnv
 
+
+# Get script directory
+MODULE_DIR = os.path.dirname(__file__)
+
 # Set hyperpaameters of the ground profile
 TILE_SIZE = [np.array([4.0, 4.0]),
              np.array([100.0, 0.05]),
@@ -17,18 +21,21 @@ TILE_INTERP_DELTA = [np.array([0.5, 1.0]),
                      np.array([0.01, 0.01])]
 TILE_SPARSITY = [1, 8, 8]
 TILE_ORIENTATION = [0.0, np.pi / 4.0, 0.0]
-TILE_SEED = [np.random.randint(0, 2 ** 32, dtype=np.uint32) for _ in range(3)]
+TILE_SEED = range(3)
 
 
 # Create a gym environment for a simple cube
-urdf_path = f"{os.environ['HOME']}/wdc_workspace/src/jiminy/unit_py/data/box_collision_mesh.urdf"
+urdf_path = f"{MODULE_DIR}/../../unit_py/data/box_collision_mesh.urdf"
 env = BaseJiminyEnv(Simulator.build(
     urdf_path, has_freeflyer=True), step_dt=0.01)
 
 # Enable constraint contact model
 engine_options = env.engine.get_options()
 engine_options['contacts']['model'] = 'constraint'
-env.engine.set_options(engine_options)
+
+# Configure integrator
+engine_options['stepper']['odeSolver'] = 'euler_explicit'
+engine_options['stepper']['dtMax'] = 1.0e-3
 
 # Generate random ground profile
 ground_params = list(starmap(random_tile_ground, zip(
@@ -42,9 +49,11 @@ env.engine.set_options(engine_options)
 sample_state_orig = env._sample_state
 
 def sample_state():
-    qpos, qvel = sample_state_orig()
-    qpos[2] += 1.0
-    qvel[-1] = 1.0
+    qpos, qvel = env._neutral(), np.zeros(env.robot.nv)
+    qpos[2] += 1.5
+    qvel[0] = 2.0
+    qvel[3] = 1.0
+    qvel[5] = 2.0
     return qpos, qvel
 
 env._sample_state = sample_state
@@ -55,7 +64,7 @@ engine_options['contacts']['torsion'] = 0.0
 env.engine.set_options(engine_options)
 
 env.reset()
-for _ in range(300):
+for _ in range(500):
     env.step()
 env.stop()
 

--- a/examples/python/double_pendulum.py
+++ b/examples/python/double_pendulum.py
@@ -66,8 +66,8 @@ engine_options["stepper"]["randomSeed"] = 0
 engine_options['contacts']['model'] = "spring_damper"
 engine_options['contacts']['stiffness'] = 1.0e6
 engine_options['contacts']['damping'] = 2000.0
-engine_options['contacts']['transitionEps'] = 0.001
 engine_options['contacts']['friction'] = 5.0
+engine_options['contacts']['transitionEps'] = 0.001
 engine_options['contacts']['transitionVelocity'] = 0.01
 
 robot.set_options(robot_options)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -97,11 +97,11 @@ deployPythonPackage("${LIBRARY_NAME}_py")
 ################ gym_jiminy ################
 
 buildPythonWheel("python/gym_${LIBRARY_NAME}/common"
-                 "python/gym_${LIBRARY_NAME}/envs"
                  "python/gym_${LIBRARY_NAME}/toolbox"
+                 "python/gym_${LIBRARY_NAME}/envs"
                  "python/gym_${LIBRARY_NAME}/rllib"
                  "${CMAKE_BINARY_DIR}/pypi/dist/gym_${LIBRARY_NAME}")
 deployPythonPackageDevelop("python/gym_${LIBRARY_NAME}/common"
-                           "python/gym_${LIBRARY_NAME}/envs"
                            "python/gym_${LIBRARY_NAME}/toolbox"
+                           "python/gym_${LIBRARY_NAME}/envs"
                            "python/gym_${LIBRARY_NAME}/rllib")

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/block_bases.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/block_bases.py
@@ -55,8 +55,8 @@ class BlockInterface:
         super().__init__(**kwargs)  # type: ignore[call-arg]
 
         # Refresh the observation and action spaces
-        self._refresh_observation_space()
-        self._refresh_action_space()
+        self._initialize_observation_space()
+        self._initialize_action_space()
 
         # Assertion(s) for type checker
         assert (self.observation_space is not None and
@@ -95,7 +95,7 @@ class BlockInterface:
             state of the block.
         """
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """Configure the observation of the block.
 
         .. note::
@@ -105,7 +105,7 @@ class BlockInterface:
         """
         raise NotImplementedError
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """Configure the action of the block.
 
         .. note::
@@ -150,7 +150,7 @@ class BaseObserverBlock(ObserverInterface, BlockInterface):
         # Initialize the block and observe interface
         super().__init__(*args, **kwargs)
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """Configure the action space of the observer.
 
         It does nothing but to return the action space of the environment
@@ -232,7 +232,7 @@ class BaseControllerBlock(ControllerInterface, BlockInterface):
         # Initialize the block and control interface
         super().__init__(*args, **kwargs)
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """Configure the observation space of the controller.
 
         It does nothing but to return the observation space of the environment
@@ -293,7 +293,7 @@ BaseControllerBlock._setup.__doc__ = \
         monitor the internal state of the controller.
     """
 
-BaseControllerBlock._refresh_action_space.__doc__ = \
+BaseControllerBlock._initialize_action_space.__doc__ = \
     """Configure the action space of the controller.
 
     .. note::

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/generic_bases.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/generic_bases.py
@@ -55,7 +55,7 @@ class ObserverInterface:
     # methods to override:
     # ----------------------------
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """Configure the observation space.
         """
         raise NotImplementedError
@@ -109,7 +109,7 @@ class ControllerInterface:
     # methods to override:
     # ----------------------------
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """Configure the action space.
         """
         raise NotImplementedError

--- a/python/gym_jiminy/common/gym_jiminy/common/controllers/proportional_derivative.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/controllers/proportional_derivative.py
@@ -91,7 +91,7 @@ class PDController(BaseControllerBlock):
         # Initialize the controller
         super().__init__(env, update_ratio)
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """Configure the action space of the controller.
 
         The action spaces corresponds to the position and velocity of motors

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -193,13 +193,14 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         self._action = zeros(self.action_space, dtype=np.float64)
         self._observation = zeros(self.observation_space)
 
-        # Register the action to the telemetry
-        if isinstance(self._action, np.ndarray) and (
-                self._action.size == self.robot.nmotors):
-            # Default case: assuming there is one scalar action per motor
-            action_headers = [
-                ".".join(("action", e)) for e in self.robot.motors_names]
-        self.register_variable("action", self._action, action_headers)
+        # Register the action to the telemetry automatically iif there is
+        # exactly one scalar action per motor.
+        if isinstance(self._action, np.ndarray):
+            action_size = self._action.size
+            if action_size > 0 and action_size == self.robot.nmotors:
+                action_headers = [
+                    ".".join(("action", e)) for e in self.robot.motors_names]
+                self.register_variable("action", self._action, action_headers)
 
     def __getattr__(self, name: str) -> Any:
         """Fallback attribute getter.

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -809,7 +809,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
                 reward += self.compute_reward_terminal(info=self._info)
 
         # Make sure the reward is not 'nan'
-        if reward != reward:
+        if np.isnan(reward):
             raise RuntimeError(
                 "The reward is 'nan'. Something went wrong with "
                 "`compute_reward` or `compute_reward_terminal` methods.")

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -1032,6 +1032,91 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         self._is_interactive = False
         self.is_training = is_training
 
+    @staticmethod
+    def evaluate(env: gym.Env,
+                 policy_fn: Callable[
+                     [DataNested, Optional[float]], DataNested],
+                 seed: Optional[int] = None,
+                 horizon: Optional[int] = None,
+                 enable_stats: bool = True,
+                 enable_replay: bool = True,
+                 **kwargs: Any) -> List[Dict[str, Any]]:
+        r"""Evaluate a policy on the environment over a complete episode.
+
+        :param env: `BaseJiminyEnv` environment instance to play with,
+                    eventually wrapped by composition, typically using
+                    `gym.Wrapper`.
+        :param policy_fn:
+            .. raw:: html
+
+                Policy to evaluate as a callback function. It must have the
+                following signature (**rew** = None at reset):
+
+            | policy_fn\(**obs**: DataNested,
+            |            **reward**: Optional[float]
+            |            \) -> DataNested  # **action**
+        :param seed: Seed of the environment to be used for the evaluation of
+                     the policy.
+                     Optional: Random seed if not provided.
+        :param horizon: Horizon of the simulation, namely maximum number of
+                        steps before termination. `None` to disable.
+                        Optional: Disabled by default.
+        :param enable_stats: Whether or not to print high-level statistics
+                             after simulation.
+                             Optional: Enabled by default.
+        :param enable_replay: Whether or not to enable replay of the
+                              simulation, and eventually recording if the extra
+                              keyword argument `record_video_path` is provided.
+                              Optional: Enabled by default.
+        :param kwargs: Extra keyword arguments to forward to the `replay`
+                       method if replay is requested.
+        """
+        # Initialize frame stack
+
+        # Make sure evaluation mode is enabled
+        is_training = env.is_training
+        if is_training:
+            env.eval()
+
+        # Reset the seed of the environment
+        env.seed(seed)
+
+        # Initialize the simulation
+        obs = env.reset()
+        reward = None
+
+        # Run the simulation
+        try:
+            info_episode = []
+            done = False
+            while not done:
+                action = policy_fn(obs, reward)
+                obs, reward, done, info = env.step(action)
+                info_episode.append(info)
+                if done or (horizon is not None and env.num_steps > horizon):
+                    break
+        except KeyboardInterrupt:
+            pass
+
+        # Restore training mode if it was enabled
+        if is_training:
+            env.train()
+
+        # Display some statistic if requested
+        if enable_stats:
+            print("env.num_steps:", env.num_steps)
+            print("cumulative reward:", env.total_reward)
+
+        # Replay the result if requested
+        if enable_replay:
+            try:
+                env.replay(**kwargs)
+            except Exception as e:  # pylint: disable=broad-except
+                # Do not fail because of replay/recording exception
+                logger.warn(str(e))
+
+        return info_episode
+
     def train(self) -> None:
         """Sets the environment in training mode.
 

--- a/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
@@ -126,7 +126,7 @@ class AcrobotJiminyEnv(BaseJiminyEnv):
         engine_options["stepper"]["dtMax"] = CONTROL_DT
         self.simulator.engine.set_options(engine_options)
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """Configure the observation of the environment.
 
         Only the state is observable, while by default, the current time,
@@ -149,7 +149,7 @@ class AcrobotJiminyEnv(BaseJiminyEnv):
         self.__state_view[0][:] = self.__state[0]
         self.__state_view[1][:] = self.__state[1]
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """Configure the action space of the environment.
 
         Replace the action space by its discrete representation depending on
@@ -158,7 +158,7 @@ class AcrobotJiminyEnv(BaseJiminyEnv):
         if not self.continuous:
             self.action_space = gym.spaces.Discrete(len(self.AVAIL_CTRL))
         else:
-            super()._refresh_action_space()
+            super()._initialize_action_space()
 
     def _sample_state(self) -> Tuple[np.ndarray, np.ndarray]:
         """Returns a valid configuration and velocity for the robot.

--- a/python/gym_jiminy/envs/gym_jiminy/envs/ant.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/ant.py
@@ -102,7 +102,7 @@ class AntEnv(BaseJiminyEnv):
 
         return qpos, qvel
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """ TODO: Write documentation.
 
         The observation space comprises:

--- a/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
@@ -12,6 +12,7 @@ from gym_jiminy.common.envs.env_locomotion import (
     F_PROFILE_WAVELENGTH, F_PROFILE_PERIOD)
 from gym_jiminy.common.controllers import PDController
 from gym_jiminy.common.pipeline import build_pipeline
+from gym_jiminy.toolbox.math import ConvexHull
 
 from pinocchio import neutral
 
@@ -37,9 +38,9 @@ PID_REDUCED_KP = np.array([
     5000.0, 5000.0, 8000.0, 4000.0, 8000.0, 5000.0])
 PID_REDUCED_KD = np.array([
     # Left leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.02, 0.01,
+    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01,
     # Right leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.02, 0.01])
+    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01])
 
 PID_FULL_KP = np.array([
     # Neck: [Y]
@@ -79,6 +80,23 @@ STD_RATIO = {
 }
 
 
+def _cleanup_contact_points(env: "AtlasJiminyEnv") -> None:
+    contact_frames_idx = env.robot.contact_frames_idx
+    contact_frames_names = env.robot.contact_frames_names
+    num_contacts = int(len(env.robot.contact_frames_idx) // 2)
+    for contact_slice in (slice(num_contacts), slice(num_contacts, None)):
+        contact_positions = np.stack([
+            env.robot.pinocchio_data.oMf[frame_idx].translation
+            for frame_idx in contact_frames_idx[contact_slice]], axis=0)
+        contact_bottom_idx = np.argsort(
+            contact_positions[:, 2])[:int(num_contacts//2)]
+        convex_hull = ConvexHull(contact_positions[contact_bottom_idx, :2])
+        env.robot.remove_contact_points([
+            contact_frames_names[contact_slice][i]
+            for i in set(range(num_contacts)).difference(
+                contact_bottom_idx[convex_hull._vertex_indices])])
+
+
 class AtlasJiminyEnv(WalkerJiminyEnv):
     def __init__(self, debug: bool = False, **kwargs: Any) -> None:
         # Get the urdf and mesh paths
@@ -98,9 +116,7 @@ class AtlasJiminyEnv(WalkerJiminyEnv):
             debug=debug), **kwargs})
 
         # Remove unrelevant contact points
-        self.robot.remove_contact_points([
-            name for name in self.robot.contact_frames_names
-            if int(name.split("_")[-1]) in (1, 3, 5, 7)])
+        _cleanup_contact_points(self)
 
     def _neutral(self):
         def joint_position_idx(joint_name):
@@ -200,9 +216,7 @@ class AtlasReducedJiminyEnv(WalkerJiminyEnv):
             step_dt=STEP_DT, debug=debug), **kwargs})
 
         # Remove unrelevant contact points
-        self.robot.remove_contact_points([
-            name for name in self.robot.contact_frames_names
-            if int(name.split("_")[-1]) in (1, 3, 5, 7)])
+        _cleanup_contact_points(self)
 
 
 AtlasPDControlJiminyEnv = build_pipeline(**{

--- a/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/atlas.py
@@ -38,9 +38,9 @@ PID_REDUCED_KP = np.array([
     5000.0, 5000.0, 8000.0, 4000.0, 8000.0, 5000.0])
 PID_REDUCED_KD = np.array([
     # Left leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01,
+    0.02, 0.01, 0.015, 0.01, 0.015, 0.01,
     # Right leg: [HpX, HpZ, HpY, KnY, AkY, AkX]
-    0.02, 0.01, 0.015, 0.01, 0.0175, 0.01])
+    0.02, 0.01, 0.015, 0.01, 0.015, 0.01])
 
 PID_FULL_KP = np.array([
     # Neck: [Y]

--- a/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
@@ -142,7 +142,7 @@ class CartPoleJiminyEnv(BaseJiminyEnv):
         engine_options["stepper"]["dtMax"] = CONTROL_DT
         self.simulator.engine.set_options(engine_options)
 
-    def _refresh_observation_space(self) -> None:
+    def _initialize_observation_space(self) -> None:
         """Configure the observation of the environment.
 
         Implement the official Gym cartpole-v1 action space. Only the state is
@@ -163,7 +163,7 @@ class CartPoleJiminyEnv(BaseJiminyEnv):
         self.observation_space = spaces.Box(
             low=-high, high=high, dtype=np.float64)
 
-    def _refresh_action_space(self) -> None:
+    def _initialize_action_space(self) -> None:
         """ TODO: Write documentation.
 
         Replace the action space by its discrete representation depending on
@@ -172,7 +172,7 @@ class CartPoleJiminyEnv(BaseJiminyEnv):
         if not self.continuous:
             self.action_space = spaces.Discrete(len(self.AVAIL_CTRL))
         else:
-            super()._refresh_action_space()
+            super()._initialize_action_space()
 
     def _sample_state(self) -> Tuple[np.ndarray, np.ndarray]:
         """ TODO: Write documentation.

--- a/python/gym_jiminy/rllib/setup.py
+++ b/python/gym_jiminy/rllib/setup.py
@@ -8,7 +8,8 @@ setup(
     name="gym_jiminy_rllib",
     version=version,
     description=(
-        "Reinforcement learning toolbox based on Ray RLlib for Gym Jiminy."),
+        "Specialized Reinforcement learning toolbox based on Ray RLlib for "
+        "Gym Jiminy."),
     author="Alexis Duburcq",
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",

--- a/python/gym_jiminy/toolbox/setup.py
+++ b/python/gym_jiminy/toolbox/setup.py
@@ -8,14 +8,15 @@ setup(
     name="gym_jiminy_toolbox",
     version=version,
     description=(
-        "Reinforcement learning toolbox based on Pytorch for Gym Jiminy."),
+        "Generic Reinforcement learning toolbox based on Pytorch for Gym "
+        "Jiminy."),
     author="Alexis Duburcq",
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",
     license="MIT",
     python_requires=">=3.6,<3.10",
     classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/python/gym_jiminy/toolbox/setup.py
+++ b/python/gym_jiminy/toolbox/setup.py
@@ -29,7 +29,7 @@ setup(
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),
     install_requires=[
-        f"gym_jiminy=={version}"
+        f"gym_jiminy_toolbox=={version}"
     ],
     zip_safe=False
 )

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -17,7 +17,7 @@ from jiminy_py.viewer import Viewer
 from gym_jiminy.envs import AtlasPDControlJiminyEnv, CassiePDControlJiminyEnv
 
 
-IMAGE_DIFF_THRESHOLD = 0.3
+IMAGE_DIFF_THRESHOLD = 1.0
 
 
 class PipelineControl(unittest.TestCase):

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -42,7 +42,7 @@ class PipelineControl(unittest.TestCase):
             :, self.env.controller.motor_to_encoder]
 
         # Run the simulation
-        while self.env.stepper_state.t < 14.0:
+        while self.env.stepper_state.t < 16.0:
             self.env.step(action_init)
 
         # Get the final posture of the robot as an RGB array

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -41,7 +41,7 @@ class PipelineControl(unittest.TestCase):
         action_init['Q'], action_init['V'] = encoder_data[
             :, self.env.controller.motor_to_encoder]
 
-        # Run the simulation during 12s
+        # Run the simulation
         while self.env.stepper_state.t < 12.0:
             self.env.step(action_init)
 

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -42,7 +42,7 @@ class PipelineControl(unittest.TestCase):
             :, self.env.controller.motor_to_encoder]
 
         # Run the simulation
-        while self.env.stepper_state.t < 12.0:
+        while self.env.stepper_state.t < 14.0:
             self.env.step(action_init)
 
         # Get the final posture of the robot as an RGB array

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -41,7 +41,7 @@ setup(
     license="MIT",
     python_requires=">=3.6,<3.10",
     classifiers=[
-        "Development Status :: 5 - Production/Stable",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/python/jiminy_py/src/jiminy_py/dynamics.py
+++ b/python/jiminy_py/src/jiminy_py/dynamics.py
@@ -658,19 +658,19 @@ def compute_inverse_dynamics(robot: jiminy.Model,
         pnc_model, pnc_data, position, velocity, acceleration)
     pin.updateFramePlacements(pnc_model, pnc_data)
 
-    # Compute inverted inertia matrix, taking into account rotor inertias
-    jiminy.crba(pnc_model, pnc_data, position)
-    pin.cholesky.decompose(pnc_model, pnc_data)
+    # Compute constraint jacobian and drift
+    robot.compute_constraints(position, velocity)
+    J = robot.get_constraints_jacobian()
+    drift = robot.get_constraints_drift()
+
+    # No need to compute the internal matrix using `crba` nor to perform the
+    # cholesky decomposition since it is already done by `compute_constraints`
+    # internally.
     M_inv = pin.cholesky.computeMinv(pnc_model, pnc_data)
 
     # Compute non-linear effects
     pin.nonLinearEffects(pnc_model, pnc_data, position, velocity)
     nle = pnc_data.nle
-
-    # Compute constraint jacobian and drift
-    robot.compute_constraints(position, velocity)
-    J = robot.get_constraints_jacobian()
-    drift = robot.get_constraints_drift()
 
     # Compute constraint forces
     jiminy.computeJMinvJt(pnc_model, pnc_data, J, False)

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -312,6 +312,8 @@ def build_robot_from_log(
     robot.initialize(urdf_path, has_freeflyer, mesh_package_dirs)
     robot.set_options(all_options["system"]["robot"])
     robot.pinocchio_model.loadFromString(pinocchio_model_str)
+    robot.pinocchio_data.loadFromString(
+        robot.pinocchio_model.createData().saveToString())
 
     return robot
 

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -341,10 +341,11 @@ def emulate_sensors_data_from_log(log_data: Dict[str, np.ndarray],
         sensor_fieldnames = getattr(jiminy, sensor_type).fieldnames
         for name in sensors_names:
             sensor = robot.get_sensor(sensor_type, name)
-            if any(field.startswith(sensor.name) for field in log_data.keys()):
+            log_fieldnames = [
+                '.'.join((sensor.name, field)) for field in sensor_fieldnames]
+            if log_fieldnames[0] in log_data.keys():
                 sensor_log = np.stack([
-                    log_data['.'.join((sensor.name, field))]
-                    for field in sensor_fieldnames], axis=-1)
+                    log_data[field] for field in log_fieldnames], axis=-1)
                 sensors_set.append(sensor)
                 sensors_log.append(sensor_log)
 

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -777,6 +777,7 @@ class Simulator:
         engine_options['stepper'] = engine_options_copy['stepper']
         engine_options['world'] = engine_options_copy['world']
         engine_options['joints'] = engine_options_copy['joints']
+        engine_options['constraints'] = engine_options_copy['constraints']
         engine_options['contacts'] = engine_options_copy['contacts']
         engine_options['telemetry'] = engine_options_copy['telemetry']
         return options

--- a/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
@@ -878,6 +878,23 @@ class Panda3dApp(panda3d_viewer.viewer_app.ViewerApp):
                     return
                 node.clear_render_mode()
 
+    def append_frame(self,
+                     root_path: str,
+                     name: str,
+                     frame: Optional[FrameType] = None) -> None:
+        """Append a cartesian frame primitive node to the group.
+        """
+        model = GeomNode('axes')
+        model.add_geom(geometry.make_axes())
+        node = NodePath(model)
+        node.set_light_off()
+        node.set_render_mode_wireframe()
+        node.set_render_mode_thickness(4)
+        node.set_antialias(AntialiasAttrib.MLine)
+        node.hide(self.LightMask)
+        node.set_shader_off()
+        self.append_node(root_path, name, node, frame)
+
     def append_cone(self,
                     root_path: str,
                     name: str,
@@ -1415,6 +1432,9 @@ class Panda3dViewer(panda3d_viewer.viewer.Viewer):
 
     def set_material(self, *args: Any, **kwargs: Any) -> None:
         self._app.set_material(*args, **kwargs)
+
+    def append_frame(self, *args: Any, **kwargs: Any) -> None:
+        self._app.append_frame(*args, **kwargs)
 
     def append_cylinder(self, *args: Any, **kwargs: Any) -> None:
         self._app.append_cylinder(*args, **kwargs)

--- a/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
@@ -659,7 +659,7 @@ class Panda3dApp(panda3d_viewer.viewer_app.ViewerApp):
                     group_path = f"render/scene_root/{group_name}/"
                     # Only nodes part of user groups can be selected
                     if node_path.startswith(group_path):
-                        name = node_path[len(group_path):].split("/", 1)[0]
+                        name = node_path[len(group_path):]
                         if (group_name, name) != picked_object_prev:
                             self.picked_object = (group_name, name)
                         object_found = True

--- a/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/panda3d/panda3d_visualizer.py
@@ -816,9 +816,16 @@ class Panda3dApp(panda3d_viewer.viewer_app.ViewerApp):
                           renders a flat tile ground if not specified.
                           Optional: None by default.
         """
+        # Check if floor is currently hidden
+        is_hidden = self._floor.isHidden()
+
         # Remove existing floor and create a new one
         self._floor.remove_node()
         self._floor = self._make_floor(heightmap, show_meshes)
+
+        # Hide the floor if is was previously hidden
+        if is_hidden:
+            self._floor.hide()
 
         # Adjust frustum of the lights to project shadow over the whole scene
         for light_path in self._lights[1:]:

--- a/python/jiminy_py/src/jiminy_py/viewer/replay.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/replay.py
@@ -330,6 +330,8 @@ def play_trajectories(trajs_data: Union[
         if data:
             i = bisect_right(
                 [s.t for s in data], time_interval[0], hi=len(data)-1)
+            for f_ext in viewer_i.f_external:
+                f_ext.vector[:] = 0.0
             viewer_i.display(data[i].q, data[i].v, offset)
         if Viewer.backend.startswith('panda3d'):
             if display_com is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -2310,6 +2310,10 @@ class Viewer:
         assert self._client.model.nq == q.shape[0], (
             "The configuration vector does not have the right size.")
 
+        # Make sure the state is valid
+        if np.isnan(q).any() or np.isnan(v).any():
+            raise ValueError("The input state ('q','v') contains 'nan'.")
+
         # Apply offset on the freeflyer, if requested.
         # Note that it is NOT checking that the robot has a freeflyer.
         if xyz_offset is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -2311,7 +2311,7 @@ class Viewer:
             "The configuration vector does not have the right size.")
 
         # Make sure the state is valid
-        if np.isnan(q).any() or np.isnan(v).any():
+        if np.isnan(q).any() or (v is not None and np.isnan(v).any()):
             raise ValueError("The input state ('q','v') contains 'nan'.")
 
         # Apply offset on the freeflyer, if requested.

--- a/python/jiminy_pywrap/src/Constraints.cc
+++ b/python/jiminy_pywrap/src/Constraints.cc
@@ -169,8 +169,8 @@ namespace python
                                                      bp::return_internal_reference<>()),
                                                      &FixedFrameConstraint::setReferenceTransform)
                 .add_property("local_rotation", bp::make_function(&FixedFrameConstraint::getLocalFrame,
-                                                bp::return_value_policy<result_converter<false> >()),
-                                                &FixedFrameConstraint::setLocalFrame);
+                                                bp::return_value_policy<result_converter<false> >()))
+                .def("set_normal", &FixedFrameConstraint::setNormal);
 
             bp::class_<DistanceConstraint, bp::bases<AbstractConstraintBase>,
                        std::shared_ptr<DistanceConstraint>,

--- a/python/jiminy_pywrap/src/Robot.cc
+++ b/python/jiminy_pywrap/src/Robot.cc
@@ -86,7 +86,7 @@ namespace python
                                                  bp::return_internal_reference<>()))
                 .add_property("visual_model", bp::make_getter(&Model::visualModel_,
                                               bp::return_internal_reference<>()))
-                .add_property("pinocchio_data_th", bp::make_getter(&Model::pncDataRigidOrig_,
+                .add_property("pinocchio_data_th", bp::make_getter(&Model::pncDataOrig_,
                                                    bp::return_internal_reference<>()))
                 .add_property("pinocchio_data", bp::make_getter(&Model::pncData_,
                                                 bp::return_internal_reference<>()))

--- a/unit_py/test_double_spring_mass.py
+++ b/unit_py/test_double_spring_mass.py
@@ -243,6 +243,7 @@ class SimulateTwoMasses(unittest.TestCase):
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
+        engine_options["constraints"]["regularization"] = 0.0
         engine.set_options(engine_options)
 
         # Add a kinematic constraint on the second mass
@@ -284,6 +285,7 @@ class SimulateTwoMasses(unittest.TestCase):
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
+        engine_options["constraints"]["regularization"] = 0.0
         engine.set_options(engine_options)
 
         # Add a kinematic constraints.
@@ -345,6 +347,7 @@ class SimulateTwoMasses(unittest.TestCase):
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
+        engine_options["constraints"]["regularization"] = 0.0
         engine.set_options(engine_options)
 
         # Define some internal parameters

--- a/unit_py/test_simple_mass.py
+++ b/unit_py/test_simple_mass.py
@@ -98,6 +98,7 @@ class SimulateSimpleMass(unittest.TestCase):
 
         # configure the engine
         engine_options = engine.get_options()
+        engine_options["contacts"]["model"] = "spring_damper"
         engine_options['contacts']['stiffness'] = self.k_contact
         engine_options['contacts']['damping'] = self.nu_contact
         engine.set_options(engine_options)
@@ -234,8 +235,8 @@ class SimulateSimpleMass(unittest.TestCase):
 
         # Set some extra options of the engine
         engine_options = engine.get_options()
-        engine_options['contacts']['transitionEps'] = 1.0e-6
         engine_options['contacts']['friction'] = self.friction
+        engine_options['contacts']['transitionEps'] = 1.0e-6
         engine_options['contacts']['transitionVelocity'] = self.transtion_vel
         engine_options["stepper"]["controllerUpdatePeriod"] = self.dtMax
         engine.set_options(engine_options)

--- a/unit_py/test_simple_pendulum.py
+++ b/unit_py/test_simple_pendulum.py
@@ -118,10 +118,10 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         # Configure the engine
         engine_options = engine.get_options()
+        engine_options["world"]["gravity"] = np.zeros(6)
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
-        engine_options["world"]["gravity"] = np.zeros(6)
         engine.set_options(engine_options)
 
         # Run simulation and extract log data
@@ -531,10 +531,10 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         # Configure the engine
         engine_options = engine.get_options()
+        engine_options["world"]["gravity"] = np.zeros(6)
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
-        engine_options["world"]["gravity"] = np.zeros(6)
         engine.set_options(engine_options)
 
         # Run simulation and extract some information from log data.
@@ -607,10 +607,11 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         # Configure the engine
         engine_options = engine.get_options()
+        engine_options["world"]["gravity"] = np.zeros(6)
         engine_options["stepper"]["solver"] = "runge_kutta_dopri5"
         engine_options["stepper"]["tolAbs"] = TOLERANCE * 1e-1
         engine_options["stepper"]["tolRel"] = TOLERANCE * 1e-1
-        engine_options["world"]["gravity"] = np.zeros(6)
+        engine_options["constraints"]["regularization"] = 0.0
         engine.set_options(engine_options)
 
         # Run simulation and extract some information from log data

--- a/unit_py/utilities.py
+++ b/unit_py/utilities.py
@@ -180,7 +180,8 @@ def simulate_and_get_state_evolution(
            name = system.name
            q0[name] = x0[name][:system.robot.nq]
            v0[name] = x0[name][-system.robot.nv:]
-    engine.simulate(tf, q0, v0)
+    hresult = engine.simulate(tf, q0, v0)
+    assert hresult == jiminy.hresult_t.SUCCESS
 
     # Get log data
     log_data, _ = engine.get_log()


### PR DESCRIPTION
* [core] Enforce isotropic solution for PGS. (#467)
* [core] Compensate PGS bias to ensure maximum energy dissipation for tangential friction. (#468)
* [core] Compute PGS error in residual space. (#462)
* [core] PGS skip parameter update if irrelevant. (#464)
* [core] Force sensors now measure total external force applied on a body. 
* [core] Split constraint and contact options. (#462)
* [core] Move to next breakpoint if possible to avoid very small timesteps during integration. (#464)
* [core] Fix non-linear PGS solving of friction cone. (#461)
* [core] Fix 'removeContactPoints' if input vector is empty.
* [core] Fix timestep adjustment for fixed timestep euler explicit stepper. (#464)
* [core] Fix baumgarte stabilization of orientation for 'FixedFrameConstraint'. (#465)
* [core] Fix json dump for empty dictionary. (#466)
* [core] Remove random permutation from PGS since preserving order is important. (#467)
* [core] Fix 'JointConstraint' position difference not properly computed. (#469)
* [core] Fix telemetry header to null terminate leading to segfault. (#469)
* [core] Fix inconsistency between flexible model and data. (#469)
* [core] Use 'impulse' contact model as default. (#462)
* [core] Modify 'FixedFrameConstraint' to set ground normal instead of local rotation. (#464)
* [core] Order 'FixedFrameConstraint' components by solving order. (#467)
* [python/viewer] Add 'frame' markers. (#464)
* [python/viewer] Add support of 'pin.SE3' object for marker pose. (#465)
* [python/viewer] Support specifying marker orientation using rotation matrix. (#464)
* [python/log] Fix segfault when loading robot from log. (#466)
* [python/viewer] Exception handling and timeout if backend recorder for meshcat fails to open. (#452)
* [python/viewer] Avoid crashing when replying simulations with 'nan'. (#458)
* [python/viewer] Fix extraction of available sensor data for replay. (#463)
* [python/viewer] Keep floor hidden even if updated if it was previously hidden for panda3d backend. (#463)
* [python/viewer] Fix 'display' method if velocity is not provided. (#463)
* [python/viewer] Fix body selection for panda3d. (#465)
* [python/viewer] Do not overwrite color for 'frame' marker by default. (#464)
* [gym/common] Improve exception handling during 'step'. (#458)
* [gym/common] Do not try to register action to telemetry if empty.
* [gym/common] Add 'evaluate' method to evaluate a callback policy over a whole episode. (#453)
* [gym/common] Rename 'refresh_*' in 'initialize_' when appropriate.  (#466)
* [gym/common] Rename 'refresh_internal' in 'refresh_buffers' and add 'initialize_buffers' method. (#466)
* [gym/envs] Reduce KD gain for AkY joints of Atlas to prevent numerical instability. (#464)
* [gym/envs] Automatically detect relevant contact points for Atlas. (#464)
* [misc] Update python packages description and development status. (#458)
* [misc] Run unit tests in debug mode on Ubuntu 20.04. (#469)
