### PR TITLE
Fixes some field in model not being updated when adding flexibilities.

### DIFF
--- a/core/src/utilities/Pinocchio.cc
+++ b/core/src/utilities/Pinocchio.cc
@@ -640,6 +640,12 @@ namespace jiminy
             uint32_t incrementalNv = 0;
             for (std::size_t i = 1; i < modelInOut.joints.size(); ++i)
             {
+                // Update global model indices.
+                modelInOut->idx_qs[i] = incrementalNq;
+                modelInOut->idx_vs[i] = incrementalNv;
+                modelInOut->nqs[i] = modelInOut->joints[i].nq();
+                modelInOut->nvs[i] = modelInOut->joints[i].nv();
+
                 modelInOut.joints[i].setIndexes(i, incrementalNq, incrementalNv);
                 incrementalNq += modelInOut.joints[i].nq();
                 incrementalNv += modelInOut.joints[i].nv();


### PR DESCRIPTION
When adding a flexibility in the model, the joints are 'manually' reordered. pinocchio 2.0 added some new members to the Model class, these members were not update and where thus incorrect. 

This only impacted hessian computation - but would cause a crash when compiled in Debug.