### PR TITLE
[python/viewer] Fallback to generic direct connection through ipykernel for Meshcat.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,7 +47,7 @@ jobs:
 
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade pip
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade wheel
-        "${PYTHON_EXECUTABLE}" -m pip install --upgrade numpy
+        "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
 
         echo "RootDir=${GITHUB_WORKSPACE}" >> $GITHUB_ENV
         echo "InstallDir=${GITHUB_WORKSPACE}/install" >> $GITHUB_ENV

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,7 +66,7 @@ jobs:
 
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade pip
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade twine wheel delocate
-        "${PYTHON_EXECUTABLE}" -m pip install --upgrade numpy
+        "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
     - name: Build project dependencies
       run: |
         MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET} OSX_ARCHITECTURES=${OSX_ARCHITECTURES} \

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -59,9 +59,9 @@ jobs:
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade pip
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade twine wheel auditwheel cmake
         if [ "${{ matrix.legacy }}" == true ] ; then
-          "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.20"
+          "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.20"  # for tensorflow compat.
         else
-          "${PYTHON_EXECUTABLE}" -m pip install --upgrade numpy
+          "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
         fi
     - name: Build project dependencies
       run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -51,7 +51,7 @@ jobs:
       run: |
         sudo env "PATH=$PATH" "${GITHUB_WORKSPACE}/build_tools/easy_install_deps_ubuntu.sh"
         "${PYTHON_EXECUTABLE}" -m pip install tensorflow
-        "${PYTHON_EXECUTABLE}" -m pip install --upgrade numpy
+        "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
         "${PYTHON_EXECUTABLE}" -m pip install "torch==1.8.0+cpu" -f https://download.pytorch.org/whl/torch_stable.html
         "${PYTHON_EXECUTABLE}" -m pip install --prefer-binary "gym>=0.18.3" "stable_baselines3>=0.10" "importlib-metadata>=3.3.0"
 
@@ -126,7 +126,7 @@ jobs:
                  --disable=too-many-instance-attributes,too-many-arguments,too-few-public-methods,too-many-lines \
                  --disable=too-many-locals,too-many-branches,too-many-statements \
                  --disable=unspecified-encoding,logging-fstring-interpolation \
-                 --disable=misplaced-comparison-constant \
+                 --disable=misplaced-comparison-constant --disable=cyclic-import \
                  --generated-members=numpy.*,torch.* "gym_jiminy/"
 
           mypy --allow-redefinition --check-untyped-defs --disallow-incomplete-defs --disallow-untyped-defs \

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -45,7 +45,7 @@ jobs:
         git config --global advice.detachedHead false
         python -m pip install --upgrade pip
         python -m pip install --upgrade wheel pefile machomachomangler
-        python -m pip install --upgrade numpy
+        python -m pip install --upgrade "numpy<1.22"  # for numba compat.
         python -m pip uninstall -y pipx  # Uninstall unecessary packages causing conflicts with the new resolver
     - name: Build project dependencies
       run: |

--- a/build_tools/easy_install_deps_ubuntu.sh
+++ b/build_tools/easy_install_deps_ubuntu.sh
@@ -53,7 +53,7 @@ apt update && \
 apt install -y sudo python3-setuptools python3-pip python3-tk && \
 sudo -u $(id -nu "${SUDO_UID}") env "PATH=${PATH}" python3 -m pip install --upgrade pip && \
 sudo -u $(id -nu "${SUDO_UID}") env "PATH=${PATH}" python3 -m pip install --upgrade wheel && \
-sudo -u $(id -nu "${SUDO_UID}") env "PATH=${PATH}" python3 -m pip install --upgrade "numpy>=1.16"
+sudo -u $(id -nu "${SUDO_UID}") env "PATH=${PATH}" python3 -m pip install --upgrade "numpy>=1.16,<1.22"
 
 # Install Python 3 toolsuite for testing and documentation generation
 sudo -u $(id -nu "${SUDO_UID}") env "PATH=${PATH}" python3 -m pip install --upgrade setuptools auditwheel && \

--- a/build_tools/wheel_repair_linux.py
+++ b/build_tools/wheel_repair_linux.py
@@ -18,7 +18,7 @@ def copylib(src_path: str, dest_dir: str,
             patcher: ElfPatcher) -> Tuple[str, str]:
     # Do NOT hash filename to make it unique in the particular case of boost
     # python modules, since otherwise it will be impossible to share a common
-    # registery, which is necessary for cross module interoperability.
+    # registry, which is necessary for cross module interoperability.
     if "libboost_python" in src_path:
         src_name = os.path.basename(src_path)
         dest_path = os.path.join(dest_dir, src_name)

--- a/build_tools/wheel_repair_win.py
+++ b/build_tools/wheel_repair_win.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This tool has been copied from https://github.com/vinayak-mehta/pdftopng/blob/main/scripts/wheel_repair.py
-# and extended to supported hierarchical folder architecture with mulitple .pyd
+# and extended to supported hierarchical folder architecture with multiple .pyd
 # to update, and to move all the DLL in a common folder *package*.lib installed
 # jointly with the package itself, similarly to auditwheel on Linux platform.
 #(see also https://discuss.python.org/t/delocate-auditwheel-but-for-windows/2589/9).

--- a/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
+++ b/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
@@ -60,7 +60,7 @@ namespace pinocchio_overload
          pinocchio::container::aligned_vector<ForceDerived>     const & fext)
     {
         (void) pinocchio::rnea(model, data, q, v, a, fext);
-        data.tau += model.rotorInertia.asDiagonal() * a;
+        data.tau.array() += model.rotorInertia.array() * a.array();
         return data.tau;
     }
 

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -146,9 +146,9 @@ setup(
           # Check PEP8 conformance of Python native code
           "flake8",
           # Python linter
-          "pylint",
+          "pylint>=2.12.2",
           # Python static type checker
-          "mypy",
+          "mypy>=0.931",
           # Generate Python docs and render '.rst' nicely
           "sphinx",
           # 'Read the Docs' Sphinx docs style
@@ -162,9 +162,10 @@ setup(
           # Bridge between doxygen and sphinx. Used to generate C++ API docs
           "breathe",
           # Repair wheels to embed shared libraries.
-          # Since 3.2.0, it is now possible to use custom patcher, and new
-          # manylinux_2_24 images are supported since 3.3.0
-          "auditwheel>=3.3.0"
+          # - 3.2.0: enable defining custom patcher
+          # - 3.3.0: Support Python 3.9 and manylinux_2_24 images
+          # - 4.0.0: Many bug fixes, including RPATH of dependencies
+          "auditwheel>=4.0.0"
       ]
     },
     zip_safe=False

--- a/python/jiminy_py/src/jiminy_py/core/_pinocchio_init.py
+++ b/python/jiminy_py/src/jiminy_py/core/_pinocchio_init.py
@@ -2,7 +2,7 @@ import pinocchio as pin
 
 
 # Use numpy array by default for Eigenpy and Pinocchio incidentally
-__import__('eigenpy').switchToNumpyArray()
+__import__("eigenpy").switchToNumpyArray()
 
 
 # Do not load the geometry of the ground is is not an actually geometry but

--- a/python/jiminy_py/src/jiminy_py/viewer/meshcat/index.html
+++ b/python/jiminy_py/src/jiminy_py/viewer/meshcat/index.html
@@ -34,10 +34,13 @@
                 }
             };
 
-            // Connect the viewer to the existing server, using the
-            // usual websocket on desktop, though kernel communication
-            // in Google Colaboratory or Jupyter notebooks.
+            // Connect the viewer to the existing server, though direct ZMP
+            // websocket in standalone browser or though kernel communication
+            // in notebooks.
             try {
+                // Set externally by python in interactive mode
+                var ws_path = undefined;
+
                 if (typeof google !== 'undefined') {
                     (async () => {
                         viewer.connection = await google.colab.kernel.comms.open("meshcat", "meshcat:open");
@@ -58,16 +61,116 @@
                         viewer.handle_command_bytearray(new Uint8Array(message.buffers[0].buffer));
                     });
                     viewer.connection.on_close(function(message) {
-                        viewer.connection = null;  // The connection is no longer available
                         console.log("connection to Jupyter kernel closed:", message);
+                        viewer.connection = null;  // The connection is no longer available
                     });
                 }
-                else {
-                    var ws_url = undefined;
-                    viewer.connect(ws_url);
+                else if (ws_path !== undefined) {
+                    // Connect to kernel socket manually if necessary, namely for
+                    // VSCode notebooks and jupyterlab.
+                    const ws_url = "ws" + window.parent.location.origin.substring(4) + ws_path;
+                    viewer.connection = new window.WebSocket(ws_url);
+
+                    // Define UUID generation utility to identify the comm and messages
+                    function uuid() {
+                        return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
+                            (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
+                        );
+                    };
+
+                    // Define message deserialization method
+                    var deserialize_array_buffer = function (buf) {
+                        var data = new DataView(buf);
+                        var nbufs = data.getUint32(0);
+                        var offsets = [];
+                        var i;
+                        for (i = 1; i <= nbufs; i++) {
+                            offsets.push(data.getUint32(i * 4));
+                        }
+                        var json_bytes = new Uint8Array(buf.slice(offsets[0], offsets[1]));
+                        var msg = JSON.parse(
+                            (new TextDecoder('utf8')).decode(json_bytes)
+                        );
+                        msg.buffers = [];
+                        var start, stop;
+                        for (i = 1; i < nbufs; i++) {
+                            start = offsets[i];
+                            stop = offsets[i+1] || buf.byteLength;
+                            msg.buffers.push(new DataView(buf.slice(start, stop)));
+                        }
+                        return msg;
+                    };
+
+                    // Create unique comm identifier
+                    const comm_id = uuid();
+
+                    // Monkey-patch send command
+                    var send = viewer.connection.send;
+                    viewer.connection.send = function(data, msg_type) {
+                        var msg = {
+                            header : {
+                                date: new Date().toISOString(),
+                                username : "meshcat",
+                                msg_id : uuid(),
+                                session : "000000000000",
+                                version : "5.3",
+                                msg_type : msg_type || "comm_msg"
+                            },
+                            metadata : {},
+                            content : {
+                                comm_id : comm_id,
+                                target_name : "meshcat",
+                                data : data,
+                            },
+                            channel : 'shell',
+                            buffers : [],
+                            parent_header : {}
+                        };
+                        send.call(this, JSON.stringify(msg));
+                    };
+
+                    // Monkey-patch close command
+                    var close = viewer.connection.close;
+                    viewer.connection.close = function() {
+                        // For some reason, `onclose` is never called, and
+                        // calling the original `close` interferes with the
+                        // send method and the message is never received.
+                        viewer.connection.send("meshcat:close", "comm_close");
+                    };
+
+                    // Define event handler
+                    viewer.connection.onopen = function(event) {
+                        console.log("connection to generic ipykernel:", viewer.connection);
+                        viewer.connection.send("meshcat:open", "comm_open");
+                    };
+                    viewer.connection.onmessage = async function (event) {
+                        var data = event.data;
+                        if (data instanceof Blob) {
+                            const reader = new FileReader();
+                            reader.addEventListener('loadend', () => {
+                                var p = Promise.resolve(deserialize_array_buffer(reader.result));
+                                p.then(function(msg) {
+                                    if (msg.content.comm_id === comm_id)
+                                    {
+                                        viewer.handle_command_bytearray(new Uint8Array(msg.buffers[0].buffer));
+                                    }
+                                });
+                            });
+                            reader.readAsArrayBuffer(event.data);
+                        }
+                    };
+                    viewer.connection.onclose = function (message) {
+                        console.log("connection to generic ipykernel closed:", message);
+                        viewer.connection = null;  // The connection is no longer available
+                    };
+                }
+                else
+                {
+                    // Fallback to direct local communication through meshcat ZMQ socket
+                    viewer.connect();
                 }
             } catch (e) {
-                console.info("Not connected to MeshCat server: ", e);
+                console.info("not connected to MeshCat server: ", e);
             }
 
             // Replace the mesh grid by a filled checkerboard, similar to
@@ -143,7 +246,7 @@
                 // available.
                 if (viewer.connection !== null)
                 {
-                    console.log("Closing connection...");
+                    console.log("closing connection...");
                     viewer.connection.close();
                 }
                 return false;

--- a/python/jiminy_py/src/jiminy_py/viewer/meshcat/server.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/meshcat/server.py
@@ -153,6 +153,7 @@ class ZMQWebSocketIpythonBridge(ZMQWebSocketBridge):
             self.send_scene(comm_id=comm_id)
             self.comm_pool.add(comm_id)
             if self.is_waiting_ready_msg:
+                # Send request for acknowledgment a-posteriori
                 msg = umsgpack.packb({"type": "ready"})
                 self.forward_to_comm(comm_id, msg)
         elif cmd.startswith("close:"):


### PR DESCRIPTION
Several limitations:
* Getting the server origin is difficult. `window.location.origin` is not reliable, for instance it will fail if the notebook server is hidden behind a reverse proxy, or it is embedded in a app such as VSCode. Using a tunnel and go through the usual meshcat zmq socket is an alternative solution, but it requires setting up a server or paying a service for it. Another option would be to develop a proper widget to get access to the kernel websocket through it, but it is not solution the compatibility issue with cloud notebooks providers such as deepnote, kaggle or colab.
* It is suffering from throughput limitation that are monitored by ipython kernel. The solution would be to gather the messages whenever it is possible, for instance when updating the position for frames.
* Managing the websocket in the iFrame is problematic since when the window unload it gets closed and the delay is too short to notify the kernel in order to keep track of the number of communication opened.

To sum up, finding a way to get access to the kernel websocket instead of opening a communication manually inside the frame seems to be necessary, but there is no way to do so by design... So being generic looks like a dead end. But the current implementation is good enough to more or less work on several platforms such as mybinder and kaggle (with a little tweak of the url origin).