### PR TITLE
[python/viewer] Enable dynamic update of available/default backend. 

### DIFF
--- a/build_tools/build_install_deps_unix.sh
+++ b/build_tools/build_install_deps_unix.sh
@@ -130,6 +130,7 @@ git apply --reject --whitespace=fix "$RootDir/build_tools/patch_deps_unix/assimp
 ### Checkout hpp-fcl
 if [ ! -d "$RootDir/hpp-fcl" ]; then
   git clone https://github.com/humanoid-path-planner/hpp-fcl.git "$RootDir/hpp-fcl"
+  git config --global url."https://".insteadOf git://
 fi
 cd "$RootDir/hpp-fcl"
 git reset --hard
@@ -143,6 +144,7 @@ git checkout --force "v8.0.2"
 ### Checkout pinocchio and its submodules
 if [ ! -d "$RootDir/pinocchio" ]; then
   git clone https://github.com/stack-of-tasks/pinocchio.git "$RootDir/pinocchio"
+  git config --global url."https://".insteadOf git://
 fi
 cd "$RootDir/pinocchio"
 git reset --hard

--- a/build_tools/build_install_deps_windows.ps1
+++ b/build_tools/build_install_deps_windows.ps1
@@ -119,6 +119,7 @@ git apply --reject --whitespace=fix "$RootDir/build_tools/patch_deps_windows/ass
 ### Checkout hpp-fcl
 if (-not (Test-Path -PathType Container "$RootDir/hpp-fcl")) {
   git clone https://github.com/humanoid-path-planner/hpp-fcl.git "$RootDir/hpp-fcl"
+  git config --global url."https://".insteadOf git://
 }
 Set-Location -Path "$RootDir/hpp-fcl"
 git reset --hard
@@ -133,6 +134,7 @@ git checkout --force "v8.0.2"
 ### Checkout pinocchio and its submodules, then apply some patches (generated using `git diff --submodule=diff`)
 if (-not (Test-Path -PathType Container "$RootDir/pinocchio")) {
   git clone https://github.com/stack-of-tasks/pinocchio.git "$RootDir/pinocchio"
+  git config --global url."https://".insteadOf git://
 }
 Set-Location -Path "$RootDir/pinocchio"
 git reset --hard

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -4,7 +4,6 @@ the official OpenAI Gym API and extended it to add more functionalities.
 """
 import os
 import tempfile
-import multiprocessing
 from copy import deepcopy
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -24,7 +23,8 @@ from jiminy_py.core import (EncoderSensor as encoder,
                             ContactSensor as contact,
                             ForceSensor as force,
                             ImuSensor as imu)
-from jiminy_py.viewer.viewer import DEFAULT_CAMERA_XYZRPY_REL, Viewer
+from jiminy_py.viewer.viewer import (
+    DEFAULT_CAMERA_XYZRPY_REL, check_display_available, Viewer)
 from jiminy_py.dynamics import compute_freeflyer_state_from_fixed_body
 from jiminy_py.simulator import Simulator
 from jiminy_py.log import extract_data_from_log
@@ -130,7 +130,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
 
         # Set the available rendering modes
         self.metadata['render.modes'] = ['rgb_array']
-        if not multiprocessing.current_process().daemon:
+        if check_display_available():
             self.metadata['render.modes'].append('human')
 
         # Define some proxies for fast access

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -24,8 +24,7 @@ from jiminy_py.core import (EncoderSensor as encoder,
                             ContactSensor as contact,
                             ForceSensor as force,
                             ImuSensor as imu)
-from jiminy_py.viewer.viewer import (
-    DEFAULT_CAMERA_XYZRPY_REL, get_backends_available, Viewer)
+from jiminy_py.viewer.viewer import DEFAULT_CAMERA_XYZRPY_REL, Viewer
 from jiminy_py.dynamics import compute_freeflyer_state_from_fixed_body
 from jiminy_py.simulator import Simulator
 from jiminy_py.log import extract_data_from_log
@@ -131,7 +130,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
 
         # Set the available rendering modes
         self.metadata['render.modes'] = ['rgb_array']
-        if not multiprocessing.current_process()._config.get('daemon'):
+        if not multiprocessing.current_process().daemon:
             self.metadata['render.modes'].append('human')
 
         # Define some proxies for fast access
@@ -1383,6 +1382,9 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         :param measure: Observation of the environment.
         :param action: Desired motors efforts.
         """
+        # Assertion(s) for type checker
+        assert self.action_space is not None
+
         # Check if the action is out-of-bounds, in debug mode only
         if self.debug and not self.action_space.contains(action):
             logger.warn("The action is out-of-bounds.")

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -908,7 +908,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
                     log_data, action_headers, as_dict=True).items()})
 
         # Add action tab
-        self.figure.add_tab("Action", t, tab_data)
+        self.simulator.figure.add_tab("Action", t, tab_data)
 
     def replay(self, enable_travelling: bool = True, **kwargs: Any) -> None:
         """Replay the current episode until now.

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -4,6 +4,7 @@ the official OpenAI Gym API and extended it to add more functionalities.
 """
 import os
 import tempfile
+import multiprocessing
 from copy import deepcopy
 from collections import OrderedDict
 from collections.abc import Mapping
@@ -23,7 +24,8 @@ from jiminy_py.core import (EncoderSensor as encoder,
                             ContactSensor as contact,
                             ForceSensor as force,
                             ImuSensor as imu)
-from jiminy_py.viewer.viewer import DEFAULT_CAMERA_XYZRPY_REL, Viewer
+from jiminy_py.viewer.viewer import (
+    DEFAULT_CAMERA_XYZRPY_REL, get_backends_available, Viewer)
 from jiminy_py.dynamics import compute_freeflyer_state_from_fixed_body
 from jiminy_py.simulator import Simulator
 from jiminy_py.log import extract_data_from_log
@@ -92,13 +94,6 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
     to implement one. It has been designed to be highly flexible and easy to
     customize by overloading it to fit the vast majority of users' needs.
     """
-    metadata = {
-        'render.modes': ['human', 'rgb_array'],
-    }
-
-    observation_space: spaces.Space
-    action_space: spaces.Space
-
     def __init__(self,
                  simulator: Simulator,
                  step_dt: float,
@@ -134,6 +129,11 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         self.enforce_bounded_spaces = enforce_bounded_spaces
         self.debug = debug
 
+        # Set the available rendering modes
+        self.metadata['render.modes'] = ['rgb_array']
+        if not multiprocessing.current_process()._config.get('daemon'):
+            self.metadata['render.modes'].append('human')
+
         # Define some proxies for fast access
         self.engine: jiminy.EngineMultiRobot = self.simulator.engine
         self.stepper_state: jiminy.StepperState = self.engine.stepper_state
@@ -151,10 +151,10 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         self.rg = np.random.Generator(np.random.Philox())
         self.log_path: Optional[str] = None
 
-        # Whether or not evaluation mode is active
+        # Whether evaluation mode is active
         self.is_training = True
 
-        # Whether or not play interactive mode is active
+        # Whether play interactive mode is active
         self._is_interactive = False
 
         # Information about the learning process
@@ -832,31 +832,36 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         return obs, reward, done, deepcopy(self._info)
 
     def render(self,
-               mode: str = 'human',
+               mode: Optional[str] = None,
                **kwargs: Any) -> Optional[np.ndarray]:
-        """Render the current state of the robot.
-
-        .. note::
-            Do not suport Multi-Rendering RGB output for now.
+        """Render the world.
 
         :param mode: Rendering mode. It can be either 'human' to display the
-                     current simulation state, or 'rgb_array' to return
-                     instead a snapshot of it as an RGB array without showing
-                     it on the screen.
+                     current simulation state, or 'rgb_array' to return a
+                     snapshot as an RGB array without showing it on the screen.
+                     Optional: 'human' by default if available, 'rgb_array'
+                     otherwise.
         :param kwargs: Extra keyword arguments to forward to
                        `jiminy_py.simulator.Simulator.render` method.
 
         :returns: RGB array if 'mode' is 'rgb_array', None otherwise.
         """
-        if mode == 'human':
-            return_rgb_array = False
-        elif mode == 'rgb_array':
-            return_rgb_array = True
-        else:
-            raise ValueError(f"Rendering mode {mode} not supported.")
+        # Handling of default rendering mode
+        if mode is None:
+            if 'human' in self.metadata['render.modes']:
+                mode = 'human'
+            else:
+                mode = 'rgb_array'
 
-        return self.simulator.render(**{
-            'return_rgb_array': return_rgb_array, **kwargs})
+        # Make sure the rendering mode is valid.
+        # Note that it is not possible to raise an exception, because the
+        # default is overwritten by gym wrappers by mistake to 'human'.
+        if mode not in self.metadata['render.modes']:
+            mode = 'rgb_array'
+
+        # Call base implementation
+        return self.simulator.render(
+            return_rgb_array=(mode == 'rgb_array'), **kwargs)
 
     def plot(self, **kwargs: Any) -> None:
         """Display common simulation data and action over time.

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -18,12 +18,12 @@ DataNested = StructNested[np.ndarray]  # type: ignore
 
 
 def _space_nested_raw(space_nested: gym.Space) -> StructNested[gym.Space]:
-    """Replace any `gym.spaces.Dict` by the raw `OrderedDict` dict it contains.
+    """Replace any `gym.spaces.Dict|Tuple` by the raw `OrderedDict|tuple` it
+    contains for inter-operability with gym<0.23.0.
 
     .. note::
         It is necessary because non primitive objects must inherit from
         `collection.abc.Mapping|Sequence` for `dm-tree` to operate on them.
-        # TODO: support of gym.spaces.Tuple is expected for gym>=0.23.0.
     """
     return tree.traverse(
         lambda space: _space_nested_raw(space.spaces) if isinstance(

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
@@ -27,7 +27,7 @@ from ray import ray_constants
 from ray._private import services
 from ray._private.gcs_utils import AvailableResources
 from ray._private.test_utils import monitor_memory_usage
-from ray._raylet import GlobalStateAccessor
+from ray._raylet import GlobalStateAccessor  # type: ignore[attr-defined]
 from ray.exceptions import RayTaskError
 from ray.tune.logger import Logger, TBXLogger
 from ray.tune.utils.util import SafeFallbackEncoder
@@ -41,6 +41,7 @@ from ray.rllib.env.env_context import EnvContext
 from ray.rllib.evaluation.worker_set import WorkerSet
 
 from jiminy_py.viewer import play_logs_files
+from gym_jiminy.common.envs import BaseJiminyEnv
 from gym_jiminy.common.utils import clip, DataNested
 
 try:
@@ -531,6 +532,7 @@ def train(train_agent: Trainer,
                 log_files_tmp = []
                 test_env = train_agent.env_creator(
                     train_agent.config["env_config"])
+                assert isinstance(test_env, BaseJiminyEnv)
                 seed = train_agent.config["seed"] or 0
                 for i in range(evaluation_num):
                     # Evaluate the policy once
@@ -608,9 +610,9 @@ def test(test_agent: Trainer,
          n_frames_stack: int = 1,
          enable_stats: bool = True,
          enable_replay: bool = True,
-         test_env: Optional[gym.Env] = None,
+         test_env: Optional[BaseJiminyEnv] = None,
          viewer_kwargs: Optional[Dict[str, Any]] = None,
-         **kwargs: Any) -> Union[gym.Env, List[Dict[str, Any]]]:
+         **kwargs: Any) -> Union[BaseJiminyEnv, List[Dict[str, Any]]]:
     """Test a model on a specific environment using a given agent.
 
     .. note::

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
@@ -644,6 +644,7 @@ def test(test_agent: Trainer,
     if test_env is None:
         test_env = test_agent.env_creator(EnvContext(
             **test_agent.config["env_config"], **kwargs))
+    assert isinstance(test_env, BaseJiminyEnv)
 
     # Get policy model
     policy = test_agent.get_policy()

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -501,18 +501,19 @@ class Simulator:
                 robot_name = self.viewer.robot_name
                 scene_name = self.viewer.scene_name
 
-            # Handling of default backend
-            self.viewer_backend = self.viewer_backend or Viewer.backend
-
             # Create new viewer instance
+            viewer_backend = self.viewer_backend or Viewer.backend
             self.viewer = Viewer(self.robot,
                                  use_theoretical_model=False,
                                  open_gui_if_parent=False,
                                  **{'scene_name': scene_name,
                                     'robot_name': robot_name,
-                                    'backend': self.viewer_backend,
+                                    'backend': viewer_backend,
                                     'delete_robot_on_close': True,
                                     **kwargs})
+
+            # Backup current backend
+            self.viewer_backend = self.viewer_backend or Viewer.backend
 
             # Share the external force buffer of the viewer with the engine
             if self.is_simulation_running:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -444,9 +444,6 @@ class Viewer:
             logging.warning("Different backend already running. Closing it...")
         Viewer.backend = backend
 
-        # Configure exception handling
-        Viewer._backend_exceptions = _get_backend_exceptions(backend)
-
         # Check if the backend is still working, not just alive, if any
         if Viewer.is_alive():
             is_backend_running = True
@@ -1015,7 +1012,8 @@ class Viewer:
             elif Viewer.backend == 'meshcat':
                 # Opening a new display cell automatically if there is no other
                 # display cell already opened. The user is probably expecting a
-                # display cell to open in such cases, but there is no fixed rule.
+                # display cell to open in such cases, but there is no fixed
+                # rule.
                 open_gui = interactive_mode() and (
                     Viewer._backend_obj is None or
                     not Viewer._backend_obj.comm_manager.n_comm)
@@ -1023,6 +1021,9 @@ class Viewer:
                 open_gui = not interactive_mode()
             else:
                 open_gui = False
+
+        # Configure exception handling
+        Viewer._backend_exceptions = _get_backend_exceptions(Viewer.backend)
 
         if Viewer.backend.startswith('panda3d'):
             # Make sure that creating a new client is allowed
@@ -1096,7 +1097,7 @@ class Viewer:
                     response = zmq_socket.recv().decode("utf-8")
                     if response[:4] != "http":
                         zmq_url = None
-                except (zmq.error.Again, zmq.error.ZMQError):
+                except Viewer._backend_exceptions:
                     zmq_url = None
                 zmq_socket.close(linger=5)
                 if zmq_url is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -94,11 +94,11 @@ def get_backends_available() -> Dict[str, type]:
     # In must be a function, otherwise it would only be run once at import by
     # the main thread only.
     backends_available = {'panda3d-sync': Panda3dVisualizer}
-    if not multiprocessing.current_process()._config.get('daemon'):
+    if not multiprocessing.current_process().daemon:
         backends_available.update({'meshcat': MeshcatVisualizer,
                                    'panda3d': Panda3dVisualizer})
         try:
-            from .panda3d.panda3d_widget import Panda3dQWidget
+            from .panda3d.panda3d_widget import Panda3dQWidget  # noqa: F401
             backends_available['panda3d-qt'] = Panda3dVisualizer
         except ImportError:
             pass
@@ -119,7 +119,7 @@ def default_backend() -> str:
     """
     if interactive_mode():
         return 'meshcat'
-    elif not multiprocessing.current_process()._config.get('daemon'):
+    elif not multiprocessing.current_process().daemon:
         return 'panda3d'
     else:
         return 'panda3d-sync'


### PR DESCRIPTION
* [python/viewer] Enable dynamic update of available/default backend. 
* [python/viewer] Add synchronous panda3d backend for offscreen only subprocess rendering.
* [python/viewer] Fix support of Intel GPU for rendering and on-demand Nvidia with panda3d.
* [python/viewer] Default to sync panda3d backend if onscreen impossible.
* [python/viewer] Disable shader in headless mode with panda3d to avoid segfault.
