### PR TITLE
[gym/envs] Stop relying on now deprecated gym seeding and GoalEnv.

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-test-and-publish-pypi-manylinux:
     name: >-
-      (${{ matrix.container }}) (${{ matrix.PYTHON_VERSION }}) (${{ matrix.legacy }})
+      (${{ matrix.container }}) (${{ matrix.PYTHON_VERSION }})
       Build and run the unit tests. Then generate and publish the wheels on PyPi.
 
     strategy:
@@ -18,11 +18,6 @@ jobs:
         container: ['quay.io/pypa/manylinux2014_x86_64',
                     'quay.io/pypa/manylinux_2_24_x86_64']
         PYTHON_VERSION: ['cp36', 'cp37', 'cp38', 'cp39']
-        legacy: [false]
-        include:
-          - container: 'quay.io/pypa/manylinux_2_24_x86_64'
-            PYTHON_VERSION: 'cp38'
-            legacy: true
 
     runs-on: ubuntu-20.04
     container: ${{ matrix.container }}
@@ -58,11 +53,7 @@ jobs:
 
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade pip
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade twine wheel auditwheel cmake
-        if [ "${{ matrix.legacy }}" == true ] ; then
-          "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.20"  # for tensorflow compat.
-        else
-          "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
-        fi
+        "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
     - name: Build project dependencies
       run: |
         ./build_tools/build_install_deps_unix.sh
@@ -117,7 +108,7 @@ jobs:
       if: success() && github.repository == 'duburcqa/jiminy'
       uses: actions/upload-artifact@v1
       with:
-        name: jiminy_py-${{ matrix.PYTHON_VERSION }}-wheel-${{ matrix.legacy }}
+        name: jiminy_py-${{ matrix.PYTHON_VERSION }}-wheel
         path: build/wheelhouse
 
     #####################################################################################
@@ -134,7 +125,7 @@ jobs:
 
     - name: Publish on PyPi the wheel for Linux of Jiminy_py
       if: >-
-        success() && matrix.legacy == false &&
+        success() &&
         github.repository == 'duburcqa/jiminy' && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master
       with:
@@ -143,7 +134,7 @@ jobs:
         packages_dir: build/wheelhouse
     - name: Publish on PyPi the wheel of Gym Jiminy (Any platform / Any python3 version)
       if: >-
-        success() && matrix.container == 'quay.io/pypa/manylinux2014_x86_64' && matrix.PYTHON_VERSION == 'cp36' && matrix.legacy == false &&
+        success() && matrix.container == 'quay.io/pypa/manylinux2014_x86_64' && matrix.PYTHON_VERSION == 'cp36' &&
         github.repository == 'duburcqa/jiminy' && github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@master
       with:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ make install -j2
 
 ```
 sudo apt install -y gnupg curl wget build-essential cmake doxygen graphviz
-python -m pip install "numpy<1.20"
+python -m pip install "numpy>=1.16,<1.22"
 ```
 
 ### Jiminy dependencies build and install
@@ -185,7 +185,7 @@ You have to preinstall by yourself the (free) MSVC 2019 toolchain.
 Then, install `numpy` and `wheel`.
 
 ```
-python -m pip install wheel "numpy<1.20"
+python -m pip install wheel "numpy>=1.16,<1.22"
 ```
 
 ### Jiminy dependencies build and install

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -146,7 +146,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
 
         # Internal buffers for physics computations
         self._seed: List[np.uint32] = []
-        self.rg = np.random.Generator(np.random.Philox())
+        self.rg = np.random.Generator(np.random.SFC64())
         self.log_path: Optional[str] = None
 
         # Whether evaluation mode is active
@@ -706,18 +706,14 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
 
         :returns: Updated seed of the environment
         """
-        # Generate a 8 bytes (uint64) seed using gym utils, then convert it
-        # into sequence of 4 bytes uint32 seeds. Backup only the first one.
-        # Note that hashing is used to get rid off possible correlation in the
-        # presence of concurrency.
-        self._seed = np.random.SeedSequence(seed)
+        # Generate a sequence of 3 bytes uint32 seeds
+        self._seed = list(np.random.SeedSequence(seed).generate_state(3))
 
         # Instantiate a new random number generator based on the provided seed
-        # TODO: Rather use `PCG64DXSM` once `numpy>=1.21.0` would be enforced.
-        self.rg = np.random.Generator(np.random.PCG64(self._seed))
+        self.rg = np.random.Generator(np.random.SFC64(self._seed))
 
         # Reset the seed of Jiminy Engine
-        self.simulator.seed(self._seed.generate_state(1)[0])
+        self.simulator.seed(self._seed[0])
 
         return self._seed
 

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/env_generic.py
@@ -713,6 +713,7 @@ class BaseJiminyEnv(ObserverControllerInterface, gym.Env):
         self._seed = np.random.SeedSequence(seed)
 
         # Instantiate a new random number generator based on the provided seed
+        # TODO: Rather use `PCG64DXSM` once `numpy>=1.21.0` would be enforced.
         self.rg = np.random.Generator(np.random.PCG64(self._seed))
 
         # Reset the seed of Jiminy Engine

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -18,7 +18,7 @@ DataNested = StructNested[np.ndarray]  # type: ignore[misc]
 
 
 if tuple(map(int, (gym.__version__.split(".", 4)[:3]))) < (0, 23, 0):
-    def _space_nested_raw(space_nested: gym.Space) -> StructNested[gym.Space]:
+    def _space_nested_raw(space_nested: gym.Space) -> gym.Space:
         """Replace any `gym.spaces.Dict|Tuple` by a native collection type for
         inter-operability with gym<0.23.0.
 

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -1,6 +1,5 @@
 """ TODO: Write documentation.
 """
-from pkg_resources import parse_version
 from collections import OrderedDict
 from typing import Optional, Union, Dict, Sequence, TypeVar
 
@@ -18,7 +17,7 @@ FieldNested = StructNested[str]  # type: ignore[misc]
 DataNested = StructNested[np.ndarray]  # type: ignore[misc]
 
 
-if parse_version(gym.__version__) < parse_version('0.23.0'):
+if tuple(map(int, (gym.__version__.split(".", 4)[:3]))) < (0, 23, 0):
     def _space_nested_raw(space_nested: gym.Space) -> StructNested[gym.Space]:
         """Replace any `gym.spaces.Dict|Tuple` by a native collection type for
         inter-operability with gym<0.23.0.

--- a/python/gym_jiminy/common/setup.py
+++ b/python/gym_jiminy/common/setup.py
@@ -63,7 +63,7 @@ setup(
         # - 0.18.0: dtype handling of flatten space
         # - >=0.18.0,<0.18.3 requires Pillow<8.0 to work, not compatible with
         #   Python 3.9.
-        "gym>=0.18.3,<0.22.0"
+        "gym>=0.18.3,<0.24.0"
     ],
     extras_require=extras,
     zip_safe=False

--- a/python/gym_jiminy/unit_py/test_training_toys_models.py
+++ b/python/gym_jiminy/unit_py/test_training_toys_models.py
@@ -4,7 +4,7 @@ not assessed that the viewer is working properly.
 """
 import warnings
 import unittest
-from typing import Dict, Any
+from typing import Optional, Dict, Any
 
 import numpy as np
 from torch import nn
@@ -43,18 +43,18 @@ class ToysModelsStableBaselinesPPO(unittest.TestCase):
         """
         # Agent algorithm config
         config = {}
-        config['n_steps'] = 128
-        config['batch_size'] = 128
-        config['learning_rate'] = 1.0e-3
-        config['n_epochs'] = 8
+        config['n_steps'] = 200
+        config['batch_size'] = 200
+        config['learning_rate'] = 5.0e-4
+        config['n_epochs'] = 10
         config['gamma'] = 0.99
-        config['gae_lambda'] = 0.95
+        config['gae_lambda'] = 0.9
         config['target_kl'] = None
         config['ent_coef'] = 0.0
-        config['vf_coef'] = 0.5
-        config['clip_range'] = 0.2
+        config['vf_coef'] = 1.0
+        config['clip_range'] = np.inf
         config['clip_range_vf'] = None
-        config['max_grad_norm'] = 0.5
+        config['max_grad_norm'] = np.inf
         config['seed'] = SEED
 
         # Policy model config
@@ -71,48 +71,41 @@ class ToysModelsStableBaselinesPPO(unittest.TestCase):
     @classmethod
     def _ppo_training(cls,
                       env_name: str,
-                      env_kwargs: Dict[str, Any],
-                      agent_kwargs: Dict[str, Any]) -> bool:
+                      env_kwargs: Optional[Dict[str, Any]] = None,
+                      agent_kwargs: Optional[Dict[str, Any]] = None) -> bool:
         """ Run PPO algorithm on a given algorithm and check if the reward
         threshold has been exceeded.
         """
         # Create a multiprocess environment
         train_env = make_vec_env(
-            env_id=env_name, env_kwargs=env_kwargs, n_envs=int(N_THREADS//2),
-            vec_env_cls=SubprocVecEnv, seed=SEED)
+            env_id=env_name,  env_kwargs=env_kwargs or {},
+            n_envs=int(N_THREADS//2), vec_env_cls=SubprocVecEnv, seed=SEED)
         test_env = make_vec_env(
-            env_id=env_name, env_kwargs=env_kwargs, n_envs=1,
-            vec_env_cls=DummyVecEnv, seed=SEED)
+            env_id=env_name, env_kwargs=env_kwargs or {},
+            n_envs=1, vec_env_cls=DummyVecEnv, seed=SEED)
 
         # Create the learning agent according to the chosen algorithm
         config = cls._get_default_config_stable_baselines()
-        config.update(agent_kwargs)
-        train_agent = PPO('MlpPolicy', train_env, **config, verbose=False)
+        config.update(agent_kwargs or {})
+        train_agent = PPO(
+            'MlpPolicy', train_env, **config, device='cpu', verbose=False)
         train_agent.eval_env = test_env
 
         # Run the learning process
         return train(train_agent, max_timesteps=150000)
 
-    def test_cartpole_stable_baselines(self):
-        """Solve cartpole for both continuous and discrete action spaces.
-        """
-        is_success = self._ppo_training(
-            "gym_jiminy.envs:cartpole-v0", {'continuous': True},
-            {'learning_rate': 1.0e-3})
-        self.assertTrue(is_success)
-        is_success = self._ppo_training(
-            "gym_jiminy.envs:cartpole-v0", {'continuous': False},
-            {'learning_rate': 1.0e-3})
-        self.assertTrue(is_success)
-
     def test_acrobot_stable_baselines(self):
         """Solve acrobot for both continuous and discrete action spaces.
         """
-        is_success = self._ppo_training(
-            "gym_jiminy.envs:acrobot-v0", {'continuous': True},
-            {'learning_rate': 2.0e-4})
-        self.assertTrue(is_success)
-        is_success = self._ppo_training(
-            "gym_jiminy.envs:acrobot-v0", {'continuous': False},
-            {'learning_rate': 2.0e-4})
-        self.assertTrue(is_success)
+        self.assertTrue(self._ppo_training(
+            "gym_jiminy.envs:acrobot-v0", {'continuous': True}))
+        self.assertTrue(self._ppo_training(
+            "gym_jiminy.envs:acrobot-v0", {'continuous': False}))
+
+    def test_cartpole_stable_baselines(self):
+        """Solve cartpole for both continuous and discrete action spaces.
+        """
+        self.assertTrue(self._ppo_training(
+            "gym_jiminy.envs:cartpole-v0", {'continuous': True}))
+        self.assertTrue(self._ppo_training(
+            "gym_jiminy.envs:cartpole-v0", {'continuous': False}))

--- a/python/gym_jiminy/unit_py/test_training_toys_models.py
+++ b/python/gym_jiminy/unit_py/test_training_toys_models.py
@@ -43,24 +43,26 @@ class ToysModelsStableBaselinesPPO(unittest.TestCase):
         """
         # Agent algorithm config
         config = {}
-        config['n_steps'] = 200
-        config['batch_size'] = 200
+        config['n_steps'] = 2500
+        config['batch_size'] = 250
         config['learning_rate'] = 5.0e-4
         config['n_epochs'] = 10
         config['gamma'] = 0.99
-        config['gae_lambda'] = 0.9
-        config['target_kl'] = None
+        config['gae_lambda'] = 0.95
+        config['target_kl'] = 0.1
         config['ent_coef'] = 0.0
-        config['vf_coef'] = 1.0
-        config['clip_range'] = np.inf
+        config['vf_coef'] = 0.5
+        config['clip_range'] = 0.2
         config['clip_range_vf'] = None
-        config['max_grad_norm'] = np.inf
+        config['max_grad_norm'] = 0.5
         config['seed'] = SEED
 
         # Policy model config
         config['policy_kwargs'] = {
             'net_arch': [dict(pi=[64, 64], vf=[64, 64])],
             'activation_fn': nn.Tanh,
+            'ortho_init': True,
+            'log_std_init': 1.0,
             'optimizer_kwargs': {
                 'eps': 0.0
             }

--- a/python/gym_jiminy/unit_py/utilities.py
+++ b/python/gym_jiminy/unit_py/utilities.py
@@ -22,7 +22,8 @@ def train(train_agent: BaseAlgorithm,
             reward_threshold=spec.reward_threshold)
         eval_callback = EvalCallback(
             train_agent.eval_env, callback_on_new_best=callback_reward,
-            eval_freq=10000, n_eval_episodes=10, verbose=False)
+            eval_freq=10000 // train_agent.n_envs, n_eval_episodes=10,
+            verbose=False)
     else:
         eval_callback = None
 

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -310,7 +310,7 @@ class Simulator:
         """
         out[()] = True
 
-    def seed(self, seed: int) -> None:
+    def seed(self, seed: np.uint32) -> None:
         """Set the seed of the simulation and reset the simulation.
 
         .. warning::

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -386,7 +386,7 @@ class Viewer:
                 backend = get_default_backend()
 
         # Access the current backend or create one if none is available
-        self.__is_open = True
+        self.__is_open = False
         self.is_backend_parent = not Viewer.is_alive()
         try:
             # Start viewer backend
@@ -412,6 +412,7 @@ class Viewer:
             # case where the backend process has changed in the meantime.
             self._gui = Viewer._backend_obj.gui
             self._backend_proc = Viewer._backend_proc
+            self.__is_open = True
 
             # Open gui if requested
             try:


### PR DESCRIPTION
* [gym/envs] Use fastest modern rng 'SFC64'.
* [gym/envs] Stop relying on now deprecated gym seeding and GoalEnv.
* [misc] Stop generating legacy wheels for old tensorflow releases.
* [misc] Add support of Gym<0.24.0.