### PR TITLE
[misc] Enable avx instruction set on linux wheels.

### DIFF
--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -28,6 +28,7 @@ jobs:
 
     env:
       BUILD_TYPE: "Release"
+      CMAKE_CXX_FLAGS: "-march=sandybridge"
 
     #####################################################################################
 
@@ -70,12 +71,12 @@ jobs:
         cd "$RootDir/build"
         export LD_LIBRARY_PATH="$InstallDir/lib:$InstallDir/lib64:/usr/local/lib"
         cmake "$RootDir" -DCMAKE_INSTALL_PREFIX="$InstallDir" -DCMAKE_PREFIX_PATH="$InstallDir" \
-              -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+              -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DCMAKE_VERBOSE_MAKEFILE=ON \
               -DBOOST_ROOT="$InstallDir" -DBoost_INCLUDE_DIR="$InstallDir/include" \
               -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \
               -DBoost_USE_STATIC_LIBS=ON -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
-              -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+              -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
         make -j2
 
         # Bundle the boost python dependencies with jiminy
@@ -110,16 +111,6 @@ jobs:
       with:
         name: jiminy_py-${{ matrix.PYTHON_VERSION }}-wheel
         path: build/wheelhouse
-
-    #####################################################################################
-
-    - name: Run unit tests
-      run: |
-        cd "$RootDir/build"
-        ctest
-
-        cd "$RootDir/unit_py"
-        "${PYTHON_EXECUTABLE}" -m unittest discover -v
 
     #####################################################################################
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -50,7 +50,6 @@ jobs:
     - name: Installing requirements
       run: |
         sudo env "PATH=$PATH" "${GITHUB_WORKSPACE}/build_tools/easy_install_deps_ubuntu.sh"
-        "${PYTHON_EXECUTABLE}" -m pip install tensorflow
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy<1.22"  # for numba compat.
         "${PYTHON_EXECUTABLE}" -m pip install "torch==1.8.0+cpu" --trusted-host pypi.org \
         --trusted-host pytorch.org --trusted-host download.pytorch.org --trusted-host files.pypi.org \

--- a/build_tools/build_install_deps_unix.sh
+++ b/build_tools/build_install_deps_unix.sh
@@ -28,6 +28,7 @@ if [ "${BUILD_TYPE}" == "Release" ]; then
 else
   CMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -O0 -g"
 fi
+echo "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}."
 
 ### Get the fullpath of Jiminy project
 ScriptDir="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
@@ -41,7 +42,7 @@ mkdir -p "$InstallDir"
 #   cmake helper to detect Python executable, which is not working
 #   properly when several executables exist.
 if [ -z ${PYTHON_EXECUTABLE} ]; then
-  PYTHON_EXECUTABLE=$(python -c "import sys; sys.stdout.write(sys.executable)")
+  PYTHON_EXECUTABLE=$(python3 -c "import sys; sys.stdout.write(sys.executable)")
   echo "PYTHON_EXECUTABLE is unset. Defaulting to '${PYTHON_EXECUTABLE}'."
 fi
 
@@ -210,7 +211,7 @@ mkdir -p "$RootDir/boost/build"
 
 mkdir -p "$RootDir/eigen3/build"
 cd "$RootDir/eigen3/build"
-cmake "$RootDir/eigen3" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/eigen3" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DBUILD_TESTING=OFF -DEIGEN_BUILD_PKGCONFIG=ON \
       -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 make install -j2
@@ -219,7 +220,7 @@ make install -j2
 
 mkdir -p "$RootDir/eigenpy/build"
 cd "$RootDir/eigenpy/build"
-cmake "$RootDir/eigenpy" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/eigenpy" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_PREFIX_PATH="$InstallDir" -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
       -DPYTHON_STANDARD_LAYOUT=ON -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \
@@ -233,7 +234,7 @@ make install -j2
 
 mkdir -p "$RootDir/tinyxml/build"
 cd "$RootDir/tinyxml/build"
-cmake "$RootDir/tinyxml" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/tinyxml" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -DTIXML_USE_STL" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
@@ -243,7 +244,7 @@ make install -j2
 
 mkdir -p "$RootDir/console_bridge/build"
 cd "$RootDir/console_bridge/build"
-cmake "$RootDir/console_bridge" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/console_bridge" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_SHARED_LIBS=OFF \
       -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
@@ -260,7 +261,7 @@ make install -j2
 
 mkdir -p "$RootDir/urdfdom/build"
 cd "$RootDir/urdfdom/build"
-cmake "$RootDir/urdfdom" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/urdfdom" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_PREFIX_PATH="$InstallDir" -DBUILD_TESTING=OFF \
       -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_SHARED_LIBS=OFF \
@@ -271,7 +272,7 @@ make install -j2
 
 mkdir -p "$RootDir/assimp/build"
 cd "$RootDir/assimp/build"
-cmake "$RootDir/assimp" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/assimp" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DASSIMP_BUILD_ASSIMP_TOOLS=OFF -DASSIMP_BUILD_ZLIB=ON -DASSIMP_BUILD_TESTS=OFF \
       -DASSIMP_BUILD_SAMPLES=OFF -DBUILD_DOCS=OFF -DCMAKE_C_FLAGS="${CMAKE_CXX_FLAGS}" \
@@ -284,7 +285,7 @@ make install -j2
 
 mkdir -p "$RootDir/hpp-fcl/third-parties/qhull/build"
 cd "$RootDir/hpp-fcl/third-parties/qhull/build"
-cmake "$RootDir/hpp-fcl/third-parties/qhull" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/hpp-fcl/third-parties/qhull" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DBUILD_SHARED_LIBS=OFF -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF -DBUILD_STATIC_LIBS=ON \
       -DCMAKE_C_FLAGS="${CMAKE_CXX_FLAGS}" -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Wno-conversion" \
@@ -293,7 +294,7 @@ make install -j2
 
 mkdir -p "$RootDir/hpp-fcl/build"
 cd "$RootDir/hpp-fcl/build"
-cmake "$RootDir/hpp-fcl" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/hpp-fcl" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_PREFIX_PATH="$InstallDir" -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
       -DPYTHON_STANDARD_LAYOUT=ON -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \
@@ -310,7 +311,7 @@ make install -j2
 ### Build and install pinocchio, finally !
 mkdir -p "$RootDir/pinocchio/build"
 cd "$RootDir/pinocchio/build"
-cmake "$RootDir/pinocchio" -Wno-dev -DCMAKE_CXX_STANDARD=14 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
+cmake "$RootDir/pinocchio" -Wno-dev -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX="$InstallDir" \
       -DCMAKE_OSX_ARCHITECTURES="${OSX_ARCHITECTURES}" -DCMAKE_OSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET}" \
       -DCMAKE_PREFIX_PATH="$InstallDir" -DPYTHON_EXECUTABLE="$PYTHON_EXECUTABLE" \
       -DPYTHON_STANDARD_LAYOUT=ON -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \

--- a/core/include/jiminy/core/solver/ConstraintSolvers.h
+++ b/core/include/jiminy/core/solver/ConstraintSolvers.h
@@ -97,11 +97,11 @@ namespace jiminy
 
     private:
         void ProjectedGaussSeidelIter(matrixN_t const & A,
-                                      vectorN_t const & b,
-                                      vectorN_t::SegmentReturnType x);
+                                      vectorN_t::SegmentReturnType const & b,
+                                      vectorN_t::SegmentReturnType & x);
         bool_t ProjectedGaussSeidelSolver(matrixN_t const & A,
-                                          vectorN_t const & b,
-                                          vectorN_t::SegmentReturnType x);
+                                          vectorN_t::SegmentReturnType const & b,
+                                          vectorN_t::SegmentReturnType & x);
 
     private:
         pinocchio::Model const * model_;
@@ -111,9 +111,9 @@ namespace jiminy
         float64_t tolAbs_;
         float64_t tolRel_;
 
-        matrixN_t J_;                 ///< Matrix holding the jacobian of the constraints
-        vectorN_t gamma_;             ///< Vector holding the drift of the constraints
-        vectorN_t lambda_;            ///< Vector holding the multipliers of the constraints
+        Eigen::Matrix<float64_t, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> J_;  ///< Matrix holding the jacobian of the constraints
+        vectorN_t gamma_;   ///< Vector holding the drift of the constraints
+        vectorN_t lambda_;  ///< Vector holding the multipliers of the constraints
         std::vector<ConstraintData> constraintsData_;
 
         vectorN_t b_;

--- a/core/include/jiminy/core/solver/ConstraintSolvers.h
+++ b/core/include/jiminy/core/solver/ConstraintSolvers.h
@@ -16,7 +16,8 @@ namespace jiminy
         lo(-INF),
         hi(INF),
         isZero(false),
-        fIndices()
+        fIdx(),
+        fSize(0)
         {
             // Empty on purpose
         }
@@ -25,7 +26,8 @@ namespace jiminy
         float64_t lo;
         float64_t hi;
         bool_t isZero;
-        std::vector<Eigen::Index> fIndices;
+        Eigen::Index fIdx[3];
+        std::uint_fast8_t fSize;
     };
 
     struct ConstraintData
@@ -37,7 +39,8 @@ namespace jiminy
         isBounded(true),
         isActive(true),
         dim(0),
-        blocks()
+        blocks(),
+        nBlocks(0)
         {
             // Empty on purpose
         }
@@ -51,7 +54,8 @@ namespace jiminy
         bool_t isBounded;
         bool_t isActive;
         Eigen::Index dim;
-        std::vector<ConstraintBlock> blocks;
+        ConstraintBlock blocks[3];
+        std::uint_fast8_t nBlocks;
     };
 
     class AbstractConstraintSolver

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -1416,7 +1416,7 @@ namespace jiminy
 
                 // Instantiate desired LCP solver
                 std::string const & constraintSolverType = engineOptions_->constraints.solver;
-                switch(CONSTRAINT_SOLVERS_MAP.at(constraintSolverType))
+                switch (CONSTRAINT_SOLVERS_MAP.at(constraintSolverType))
                 {
                 case constraintSolver_t::PGS:
                     systemDataIt->constraintSolver = std::make_unique<PGSSolver>(

--- a/core/src/solver/ConstraintSolvers.cc
+++ b/core/src/solver/ConstraintSolvers.cc
@@ -297,8 +297,7 @@ namespace jiminy
            Abort computation if the inertia matrix is not positive definite,
            which is never supposed to happen in theory but in practice it is
            not sure because of compunding of errors. */
-        hresult_t returnCode = pinocchio_overload::computeJMinvJt(
-            *model_, *data_, J, false);
+        hresult_t returnCode = pinocchio_overload::computeJMinvJt(*model_, *data_, J, false);
         if (returnCode != hresult_t::SUCCESS)
         {
             data_->ddq.setConstant(qNAN);


### PR DESCRIPTION
AVX instruction set have been introduced with Intel Sandy Bridge CPU back in 2011. The vast majority of personal machines and clusters should support it. The real-time is about 65x for Atlas environment on a single core compare to 50x previously.

