### PR TITLE
[core] Adding flexibility at frame no longer requires a valid URDF file.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
         shell: bash
 
     env:
-      # Pinocchio bindings do not support memory alignment for now.
+      # Python bindings for Pinocchio 2.X does not fully support memory alignment
       # CMAKE_CXX_FLAGS: "-march=haswell"
       BUILD_TYPE: "Release"
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,9 +19,9 @@ if(urdfdom_VERSION)
 else()
     message(STATUS "Found urdfdom")
 endif()
-find_package(pinocchio 2.5.6 REQUIRED NO_MODULE NO_CMAKE_SYSTEM_PATH)  # Pinocchio v2.5.6 fixes 'aba' overwritting 'data.a_gf'
-find_package(hpp-fcl 1.7.3 REQUIRED NO_MODULE NO_CMAKE_SYSTEM_PATH)    # hpp-fcl >= 1.7.3 adds serialization of shapes
-find_package(Eigen3 3.3.0 REQUIRED NO_MODULE)                          # It adds the target Eigen3::Eigen
+find_package(pinocchio 2.6.0 REQUIRED NO_MODULE NO_CMAKE_SYSTEM_PATH)  # Pinocchio 2.6.0 adds inertia information to frames
+find_package(hpp-fcl 1.7.3 REQUIRED NO_MODULE NO_CMAKE_SYSTEM_PATH)    # hpp-fcl 1.7.3 adds serialization of shapes
+find_package(Eigen3 3.3.0 REQUIRED NO_MODULE)
 
 # Pinocchio-specific stuffs
 set(COMPILE_FLAGS "-DPINOCCHIO_WITH_URDFDOM -DPINOCCHIO_WITH_HPP_FCL")

--- a/core/include/jiminy/core/utilities/Pinocchio.h
+++ b/core/include/jiminy/core/utilities/Pinocchio.h
@@ -80,10 +80,8 @@ namespace jiminy
                                                   std::string      const & childJointNameIn,
                                                   std::string      const & newJointNameIn);
 
-    hresult_t insertFlexibilityAtFixedFrameInModel(pinocchio::Model         & modelInOut,
-                                                   std::string        const & frameNameIn,
-                                                   pinocchio::Inertia const & childBodyInertiaIn,
-                                                   std::string        const & newJointNameIn);
+    hresult_t insertFlexibilityAtFixedFrameInModel(pinocchio::Model       & modelInOut,
+                                                   std::string      const & frameNameIn);
 
     hresult_t interpolate(pinocchio::Model const & modelIn,
                           vectorN_t        const & timesIn,

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -1474,6 +1474,14 @@ namespace jiminy
                 // Compute dynamics
                 a = computeAcceleration(*systemIt, *systemDataIt, q, v, u, fext);
 
+                // Make sure there is no nan at this point
+                if ((a.array() != a.array()).any())
+                {
+                    PRINT_ERROR("Impossible to compute the acceleration. Probably a "
+                                "subtree has zero inertia along an articulated axis.");
+                    return hresult_t::ERROR_GENERIC;
+                }
+
                 // Compute joints accelerations and forces
                 computeExtraTerms(*systemIt, *systemDataIt);
                 syncAccelerationsAndForces(*systemIt, *fPrevIt, *aPrevIt);

--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -1607,6 +1607,11 @@ namespace jiminy
                 PRINT_ERROR("All joint or frame names in flexibility configuration must be unique.");
                 return hresult_t::ERROR_BAD_INPUT;
             }
+            if (std::find(flexibilityNames.begin(), flexibilityNames.end(), "universe") != flexibilityNames.end())
+            {
+                PRINT_ERROR("No one can make the universe itself flexible.");
+                return hresult_t::ERROR_BAD_INPUT;
+            }
 
             // Check if the position or velocity limits have changed, and refresh proxies if so
             bool_t enablePositionLimit = boost::get<bool_t>(jointOptionsHolder.at("enablePositionLimit"));

--- a/core/src/utilities/Pinocchio.cc
+++ b/core/src/utilities/Pinocchio.cc
@@ -730,16 +730,8 @@ namespace jiminy
             modelInOut.subtrees[newJointIdx].push_back(modelInOut.subtrees[childJointIdx][i]);
         }
 
-        /* Add weightless body.
-           In practice having a zero inertia makes some of pinocchio algorithm
-           crash, so we set a very small value instead: 1g. Anything below
-           creates numerical instability. */
-        float64_t const mass = 1.0e-3;
-        float64_t const lengthSemiAxis = 1.0;
-        pinocchio::Inertia const inertia = pinocchio::Inertia::FromEllipsoid(
-            mass, lengthSemiAxis, lengthSemiAxis, lengthSemiAxis);
-
-        modelInOut.appendBodyToJoint(newJointIdx, inertia, SE3::Identity());
+        // Add weightless body
+        modelInOut.appendBodyToJoint(newJointIdx, pinocchio::Inertia::Zero(), SE3::Identity());
 
         /* Pinocchio requires that joints are in increasing order as we move to the
            leaves of the kinematic tree. Here this is no longer the case, as an

--- a/core/src/utilities/Pinocchio.cc
+++ b/core/src/utilities/Pinocchio.cc
@@ -541,51 +541,71 @@ namespace jiminy
                       jointIndex_t      const & firstJointIdx,
                       jointIndex_t      const & secondJointIdx)
     {
+        assert(firstJointIdx < secondJointIdx && "'firstJointIdx' must be smaller than 'secondJointIdx'.");
+
         // Only perform swap if firstJointIdx is less that secondJointId
         if (firstJointIdx < secondJointIdx)
         {
-            // Update parents for other joints.
-            for (std::size_t i = 0; i < modelInOut.parents.size(); ++i)
+            // Update parents for other joints
+            for (pinocchio::JointIndex & parent : modelInOut.parents)
             {
-                if (firstJointIdx == modelInOut.parents[i])
+                if (firstJointIdx == parent)
                 {
-                    modelInOut.parents[i] = secondJointIdx;
+                    parent = secondJointIdx;
                 }
-                else if (secondJointIdx == modelInOut.parents[i])
+                else if (secondJointIdx == parent)
                 {
-                    modelInOut.parents[i] = firstJointIdx;
+                    parent = firstJointIdx;
                 }
             }
-            // Update frame parents.
-            for (std::size_t i = 0; i < modelInOut.frames.size(); ++i)
+
+            // Update frame parents
+            for (pinocchio::Frame & frame : modelInOut.frames)
             {
-                if (firstJointIdx == modelInOut.frames[i].parent)
+                if (firstJointIdx == frame.parent)
                 {
-                    modelInOut.frames[i].parent = secondJointIdx;
+                    frame.parent = secondJointIdx;
                 }
-                else if (secondJointIdx == modelInOut.frames[i].parent)
+                else if (secondJointIdx == frame.parent)
                 {
-                    modelInOut.frames[i].parent = firstJointIdx;
+                    frame.parent = firstJointIdx;
                 }
             }
-            // Update values in subtrees.
-            for (std::size_t i = 0; i < modelInOut.subtrees.size(); ++i)
+
+            // Update values in subtrees
+            for (std::vector<pinocchio::Index> & subtree : modelInOut.subtrees)
             {
-                for (std::size_t j = 0; j < modelInOut.subtrees[i].size(); ++j)
+                for (pinocchio::Index & index : subtree)
                 {
-                    if (firstJointIdx == modelInOut.subtrees[i][j])
+                    if (firstJointIdx == index)
                     {
-                        modelInOut.subtrees[i][j] = secondJointIdx;
+                        index = secondJointIdx;
                     }
-                    else if (secondJointIdx == modelInOut.subtrees[i][j])
+                    else if (secondJointIdx == index)
                     {
-                        modelInOut.subtrees[i][j] = firstJointIdx;
+                        index = firstJointIdx;
                     }
                 }
             }
 
-            // Update vectors based on joint index: effortLimit, velocityLimit,
-            // lowerPositionLimit and upperPositionLimit.
+            // Update values in supports
+            for (std::vector<pinocchio::Index> & supports : modelInOut.supports)
+            {
+                for (pinocchio::Index & index : supports)
+                {
+                    if (firstJointIdx == index)
+                    {
+                        index = secondJointIdx;
+                    }
+                    else if (secondJointIdx == index)
+                    {
+                        index = firstJointIdx;
+                    }
+                }
+            }
+
+            /* Update vectors based on joint index: effortLimit, velocityLimit,
+               lowerPositionLimit and upperPositionLimit. */
             swapVectorBlocks(modelInOut.effortLimit,
                              modelInOut.joints[firstJointIdx].idx_v(),
                              modelInOut.joints[firstJointIdx].nv(),
@@ -596,7 +616,6 @@ namespace jiminy
                              modelInOut.joints[firstJointIdx].nv(),
                              modelInOut.joints[secondJointIdx].idx_v(),
                              modelInOut.joints[secondJointIdx].nv());
-
             swapVectorBlocks(modelInOut.lowerPositionLimit,
                              modelInOut.joints[firstJointIdx].idx_q(),
                              modelInOut.joints[firstJointIdx].nq(),
@@ -607,9 +626,24 @@ namespace jiminy
                              modelInOut.joints[firstJointIdx].nq(),
                              modelInOut.joints[secondJointIdx].idx_q(),
                              modelInOut.joints[secondJointIdx].nq());
+            swapVectorBlocks(modelInOut.rotorInertia,
+                             modelInOut.joints[firstJointIdx].idx_v(),
+                             modelInOut.joints[firstJointIdx].nv(),
+                             modelInOut.joints[secondJointIdx].idx_v(),
+                             modelInOut.joints[secondJointIdx].nv());
+            swapVectorBlocks(modelInOut.friction,
+                             modelInOut.joints[firstJointIdx].idx_v(),
+                             modelInOut.joints[firstJointIdx].nv(),
+                             modelInOut.joints[secondJointIdx].idx_v(),
+                             modelInOut.joints[secondJointIdx].nv());
+            swapVectorBlocks(modelInOut.damping,
+                             modelInOut.joints[firstJointIdx].idx_v(),
+                             modelInOut.joints[firstJointIdx].nv(),
+                             modelInOut.joints[secondJointIdx].idx_v(),
+                             modelInOut.joints[secondJointIdx].nv());
 
-            // Switch elements in joint-indexed vectors:
-            // parents, names, subtrees, joints, jointPlacements, inertias.
+            /* Switch elements in joint-indexed vectors:
+               parents, names, subtrees, joints, jointPlacements, inertias. */
             jointIndex_t const tempParent = modelInOut.parents[firstJointIdx];
             modelInOut.parents[firstJointIdx] = modelInOut.parents[secondJointIdx];
             modelInOut.parents[secondJointIdx] = tempParent;
@@ -635,8 +669,8 @@ namespace jiminy
             modelInOut.inertias[secondJointIdx] = tempInertia;
 
             /* Recompute all position and velocity indexes, as we may have
-               switched joints that didn't have the same size.
-               Skip 'universe' joint since it is not an actual joint. */
+               switched joints that didn't have the same size. It skips the
+               'universe' since it is not an actual joint. */
             int32_t incrementalNq = 0;
             int32_t incrementalNv = 0;
             for (std::size_t i = 1; i < modelInOut.joints.size(); ++i)
@@ -719,10 +753,8 @@ namespace jiminy
         return hresult_t::SUCCESS;
     }
 
-    hresult_t insertFlexibilityAtFixedFrameInModel(pinocchio::Model         & modelInOut,
-                                                   std::string        const & frameNameIn,
-                                                   pinocchio::Inertia const & childBodyInertiaIn,
-                                                   std::string        const & newJointNameIn)
+    hresult_t insertFlexibilityAtFixedFrameInModel(pinocchio::Model       & modelInOut,
+                                                   std::string      const & frameNameIn)
     {
         using namespace pinocchio;
 
@@ -742,45 +774,34 @@ namespace jiminy
         }
 
         /* Get the parent and child actual joints.
-           To this end, first get the parent joint, then get the list of
-           joints having it as parent, then goes up into the list until
-           the coresponding branch is found in order to identify the actual
-           child in the tree. */
+           To this end, first get the parent joint, next get the list of frames
+           having it as parent, finally goes all the way up into their respective
+           branch to find out whether it is part of the correct branch. */
         jointIndex_t const parentJointIdx = frame.parent;
-        std::vector<jointIndex_t> childCandidateJointsIdx;
-        for (std::size_t i = 1; i < static_cast<std::size_t>(modelInOut.njoints); ++i)
+        std::vector<frameIndex_t> childFramesIdx;
+        for (frameIndex_t i = 1; i < static_cast<frameIndex_t>(modelInOut.nframes); ++i)
         {
-            if (modelInOut.parents[i] == parentJointIdx)
+            if (modelInOut.frames[i].parent == parentJointIdx)
             {
-                childCandidateJointsIdx.push_back(i);
-            }
-        }
-
-        std::vector<jointIndex_t> childJointsIdx;
-        for (jointIndex_t const & childCandidateIdx : childCandidateJointsIdx)
-        {
-            frameIndex_t childFrameIdx;
-            std::string const & childJointName = modelInOut.names[childCandidateIdx];
-            ::jiminy::getFrameIdx(modelInOut, childJointName, childFrameIdx);
-
-            do
-            {
-                childFrameIdx = modelInOut.frames[childFrameIdx].previousFrame;
-                if (childFrameIdx == frameIdx)
+                frameIndex_t childFrameIdx = i;
+                do
                 {
-                    childJointsIdx.push_back(childCandidateIdx);
-                    break;
+                    childFrameIdx = modelInOut.frames[childFrameIdx].previousFrame;
+                    if (childFrameIdx == frameIdx)
+                    {
+                        childFramesIdx.push_back(i);
+                        break;
+                    }
                 }
+                while (childFrameIdx > 0 && modelInOut.frames[childFrameIdx].type != JOINT);
             }
-            while (childFrameIdx > 0 && modelInOut.frames[childFrameIdx].type != JOINT);
         }
 
         // Remove inertia of child body from composite body
-        Inertia childBodyInertiaInv;
-        childBodyInertiaInv.mass() = - childBodyInertiaIn.mass();
-        childBodyInertiaInv.lever() = childBodyInertiaIn.lever();
-        childBodyInertiaInv.inertia() = Symmetric3(
-            - childBodyInertiaIn.inertia().data());
+        Inertia const & childBodyInertia = frame.inertia;
+        Inertia const childBodyInertiaInv(- childBodyInertia.mass(),
+                                          childBodyInertia.lever(),
+                                          Symmetric3(- childBodyInertia.inertia().data()));
         modelInOut.appendBodyToJoint(parentJointIdx,
                                      childBodyInertiaInv,
                                      frame.placement);
@@ -790,15 +811,19 @@ namespace jiminy
         jointIndex_t const newJointIdx = modelInOut.addJoint(parentJointIdx,
                                                              JointModelSpherical(),
                                                              frame.placement,
-                                                             newJointNameIn);
-        modelInOut.appendBodyToJoint(newJointIdx, childBodyInertiaIn, SE3::Identity());
+                                                             frame.name);
+        modelInOut.appendBodyToJoint(newJointIdx, childBodyInertia, SE3::Identity());
+        modelInOut.nbodies--;  // No need to increment the number of bodies
 
-        // Add new joint to frame list
-        frameIndex_t const & newFrameIdx = modelInOut.addJointFrame(
-            newJointIdx, static_cast<int32_t>(frameIdx));
-
-        for (jointIndex_t const & childJointIdx : childJointsIdx)
+        for (frameIndex_t const & childFrameIdx : childFramesIdx)
         {
+            // Get joint index for frames that are actual joints
+            if (modelInOut.frames[childFrameIdx].type != JOINT)
+            {
+                continue;
+            }
+            jointIndex_t const & childJointIdx = modelInOut.frames[childFrameIdx].parent;
+
             // Set child joint to be a child of the new joint
             modelInOut.parents[childJointIdx] = newJointIdx;
             modelInOut.jointPlacements[childJointIdx] = frame.placement.actInv(
@@ -812,39 +837,35 @@ namespace jiminy
             }
         }
 
-        if (childJointsIdx.size() > 0)
+        // Update parent joint and previous frame for child frames
+        for (frameIndex_t const & childFrameIdx : childFramesIdx)
         {
-            jointIndex_t const & childJointIdx = *std::min_element(
-                childJointsIdx.begin(), childJointsIdx.end());
+            modelInOut.frames[childFrameIdx].parent = newJointIdx;
+            modelInOut.frames[childFrameIdx].placement = frame.placement.actInv(
+                modelInOut.frames[childFrameIdx].placement);
+        }
 
-            // Update child frames parent and previousFrame indices
-            frameIndex_t childFrameIdx;
-            std::string const & childJointName = modelInOut.names[childJointIdx];
-            ::jiminy::getFrameIdx(modelInOut, childJointName, childFrameIdx);
-            do
+        // Replace fixed frame by joint frame
+        frame.type = JOINT;
+        frame.parent = newJointIdx;
+        frame.inertia.setZero();
+        frame.placement.setIdentity();
+
+        /* Pinocchio requires joints to be stored by increasing index as we go down
+           the kinematic tree. Here this is no longer the case, as an intermediate
+           joint was appended at the end. We move it back this at the correct place
+           by doing successive permutations. */
+        jointIndex_t childJointIdx = newJointIdx;
+        for (frameIndex_t const & childFrameIdx : childFramesIdx)
+        {
+            if (modelInOut.frames[childFrameIdx].type == JOINT)
             {
-                childFrameIdx = modelInOut.frames[childFrameIdx].previousFrame;
-
-                modelInOut.frames[childFrameIdx].parent = newJointIdx;
-                modelInOut.frames[childFrameIdx].placement = frame.placement.actInv(
-                   modelInOut.frames[childFrameIdx].placement);
-
-                if (childFrameIdx == frameIdx)
-                {
-                    modelInOut.frames[childFrameIdx].previousFrame = newFrameIdx;
-                    break;
-                }
+                childJointIdx = std::min(childJointIdx, modelInOut.frames[childFrameIdx].parent);
             }
-            while (childFrameIdx > 0 && modelInOut.frames[childFrameIdx].type != JOINT);
-
-            /* Pinocchio requires that joints are in increasing order as we move to the
-            leaves of the kinematic tree. Here this is no longer the case, as an
-            intermediate joint was appended at the end. We put back this joint at the
-            correct position, by doing successive permutations. */
-            for (jointIndex_t i = childJointIdx; i < newJointIdx; ++i)
-            {
-                switchJoints(modelInOut, i, newJointIdx);
-            }
+        }
+        for (jointIndex_t i = childJointIdx; i < newJointIdx; ++i)
+        {
+            switchJoints(modelInOut, i, newJointIdx);
         }
 
         return hresult_t::SUCCESS;

--- a/python/jiminy_py/src/jiminy_py/plot.py
+++ b/python/jiminy_py/src/jiminy_py/plot.py
@@ -18,6 +18,10 @@ try:
 except ImportError:
     raise ImportError(
         "Submodule not available. Please install 'jiminy_py[plot]'.")
+except RuntimeError as e:
+    # You can get a runtime error if Matplotlib is installed but cannot be
+    # imported because of some conflicts with jupyter event loop for instance.
+    raise ImportError(e)
 from matplotlib import colors
 from matplotlib.axes import Axes
 from matplotlib.lines import Line2D

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -58,6 +58,22 @@ class Simulator:
     user only as to create a robot and associated controller if any, and
     give high-level instructions to the simulator.
     """
+    def __new__(cls, *args: Any, **kwargs: Any) -> "Simulator":
+        # Instantiate base class
+        self = super().__new__(cls)
+
+        # Viewer management
+        self.viewer = None
+        self._viewers = []
+
+        # Internal buffer for progress bar management
+        self.__pbar: Optional[tqdm] = None
+
+        # Figure holder
+        self.figure = None
+
+        return self
+
     def __init__(self,
                  robot: jiminy.Robot,
                  controller: Optional[jiminy.AbstractController] = None,
@@ -106,16 +122,6 @@ class Simulator:
         self.stepper_state = self.engine.stepper_state
         self.system_state = self.engine.system_state
         self.sensors_data = self.robot.sensors_data
-
-        # Viewer management
-        self.viewer = None
-        self._viewers = []
-
-        # Internal buffer for progress bar management
-        self.__pbar: Optional[tqdm] = None
-
-        # Figure holder
-        self.figure = None
 
         # Reset the low-level jiminy engine
         self.reset()

--- a/python/jiminy_py/src/jiminy_py/viewer/meshcat/recorder.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/meshcat/recorder.py
@@ -18,7 +18,7 @@ from .utilities import interactive_mode
 
 
 PYPPETEER_STARTUP_TIMEOUT = 300.0  # 5min to download chrome (~150Mo)
-PYPPETEER_REQUEST_TIMEOUT = 20.0
+PYPPETEER_REQUEST_TIMEOUT = 25.0
 
 
 if interactive_mode() == 2:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -2222,13 +2222,17 @@ class Viewer:
                 if t_simu > time_interval[1]:
                     break
             except Exception as e:
+                # Get backend before closing
+                backend = Viewer.backend
+
                 # Make sure the viewer is always properly closed
                 Viewer.close()
+
                 # Re-raise the original exception if unexpected
-                if Viewer.backend.startswith('panda3d'):
+                if backend.startswith('panda3d'):
                     if isinstance(e, ViewerClosedError):
                         return
-                elif Viewer.backend == 'meshcat':
+                elif backend == 'meshcat':
                     import zmq
                     if isinstance(e, (zmq.error.Again, zmq.error.ZMQError)):
                         return

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -2109,7 +2109,7 @@ class Viewer:
             update_hook()
 
         # Refresh the viewer
-        self.refresh(wait)
+        self.refresh(wait=wait)
 
     @__must_be_open
     def replay(self,

--- a/unit_py/test_simple_pendulum.py
+++ b/unit_py/test_simple_pendulum.py
@@ -495,7 +495,7 @@ class SimulateSimplePendulum(unittest.TestCase):
 
         @details This test asserts that, by adding a flexibility and a rotor
                  inertia, the output is 'sufficiently close' to a SEA system:
-                 see 'note_on_flexibilty_model.pdf' for more information as to
+                 see 'note_on_flexibility_model.pdf' for more information as to
                  why this is not a true equality.
         """
         # Physical parameters: rotor inertia, spring stiffness and damping.
@@ -510,7 +510,7 @@ class SimulateSimplePendulum(unittest.TestCase):
             'frameName': "PendulumJoint",
             'stiffness': k * np.ones(3),
             'damping': nu * np.ones(3),
-            'inertia': np.zeros(3)
+            'inertia': 1e-5 * np.ones(3)
         }]
         self.robot.set_model_options(model_options)
 


### PR DESCRIPTION
* [core] Fix wrong geometry parent joint and placement.
* [core] Fix adding flexibility at universe.
* [core] Fix adding flexibility at frames when successive fixed frames.
* [core] Check if flexible joints are unique.
* [core] Check if acceleration is valid at init.
* [core] Diagnose invalid flexibility parameters.
* [core] Add missing noalias in ABA.
* [core] Adding deformation point at frame no longer requires a valid URDF file.
* [python/simulator] Fix destructor exception.
* [python/viewer] Fix exception handling when closing viewer during replay.
* [python/viewer] Increase recorder capture frame timeout for meshcat.
* [python/plot] Catch Runtime error when importing Matplotlib.