### PR TITLE
Fix bugs in creation of flexible model.

### DIFF
--- a/core/src/robot/Model.cc
+++ b/core/src/robot/Model.cc
@@ -1457,21 +1457,22 @@ namespace jiminy
                     {
                         // Only the frame name remains unchanged no matter what
                         pinocchio::Frame const & frameOrig = pncModelOrig_.frames[geom.parentFrame];
-                        pinocchio::JointIndex const jointIdxOrig = frameOrig.parent;
+                        std::string const parentJointName = pncModelOrig_.names[frameOrig.parent];
                         pinocchio::FrameIndex const frameIdx = pncModel_.getFrameId(frameOrig.name);
                         pinocchio::Frame const & frame = pncModel_.frames[frameIdx];
-                        pinocchio::JointIndex const jointIdx = frame.parent;
+                        pinocchio::JointIndex const newParentIdx = frame.parent;
+                        pinocchio::JointIndex const oldParentIdx = pncModel_.getJointId(parentJointName);
                         geom.parentFrame = frameIdx;
-                        geom.parentJoint = jointIdx;
+                        geom.parentJoint = newParentIdx;
 
                         /* Compute the relative displacement between the new and old joint placement
                            wrt their common parent joint. */
                         pinocchio::SE3 geomPlacementRef = pinocchio::SE3::Identity();
-                        for(pinocchio::JointIndex i=jointIdx; i >= jointIdxOrig && i > 0; i=pncModel_.parents[i])
+                        for(pinocchio::JointIndex i=newParentIdx; i > oldParentIdx && i > 0; i=pncModel_.parents[i])
                         {
                             geomPlacementRef = pncModel_.jointPlacements[i] * geomPlacementRef;
                         }
-                        geom.placement = geomPlacementRef.actInv(pncModelOrig_.jointPlacements[frameOrig.parent]).act(geom.placement);
+                        geom.placement = geomPlacementRef.actInv(geom.placement);
                     }
                 }
             }

--- a/core/src/utilities/Pinocchio.cc
+++ b/core/src/utilities/Pinocchio.cc
@@ -719,7 +719,6 @@ namespace jiminy
             newJointIdx, static_cast<int32_t>(modelInOut.frames[childFrameIdx].previousFrame));
 
         // Update child joint previousFrame index
-        modelInOut.frames[childFrameIdx].parent = newJointIdx;
         modelInOut.frames[childFrameIdx].previousFrame = newFrameIdx;
         modelInOut.frames[childFrameIdx].placement = SE3::Identity();
 

--- a/core/unit/CMakeLists.txt
+++ b/core/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(Threads)
 # Define the list of unit test files
 set(UNIT_TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/EngineSanityCheck.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/ModelTest.cc"
 )
 
 # Create the unit test executable

--- a/core/unit/ModelTest.cc
+++ b/core/unit/ModelTest.cc
@@ -1,0 +1,92 @@
+// Test the sanity of the simulation engine.
+// The tests in this file verify that the behavior of a simulated system matches
+// real-world physics, and that no memory is allocated by Eigen during a simulation.
+// The test system is a double inverted pendulum.
+#include <gtest/gtest.h>
+
+#define EIGEN_RUNTIME_NO_MALLOC
+
+#include "jiminy/core/robot/Model.h"
+#include "jiminy/core/utilities/Helpers.h"
+#include "jiminy/core/Types.h"
+
+#include "pinocchio/algorithm/joint-configuration.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
+#include "pinocchio/algorithm/frames.hpp"
+#include "pinocchio/algorithm/geometry.hpp"
+
+using namespace jiminy;
+
+float64_t const TOLERANCE = 1e-9;
+
+
+TEST(Model, CreateFlexible)
+{
+    // Create a flexible model, and very that it makes sense.
+
+    // Double pendulum model
+    std::string const dataDirPath(UNIT_TEST_DATA_DIR);
+    auto const urdfPath = dataDirPath + "/branching_pendulum.urdf";
+
+    // All joints actuated.
+    auto model = std::make_shared<Model>();
+    model->initialize(urdfPath, true, std::vector<std::string>(), true);
+
+    // We now have a rigid robot: perform rigid computation on this.
+    auto q = pinocchio::randomConfiguration(model->pncModel_);
+    // Reset freeflyer to finite value.
+    q[0] = 42;
+    q[1] = 42;
+    q[2] = 42;
+    auto pncData = pinocchio::Data(model->pncModel_);
+    pinocchio::framesForwardKinematics(model->pncModel_, pncData, q);
+
+    // Model is rigid, so configuration should not change.
+    vectorN_t qflex;
+    ASSERT_TRUE(model->getFlexibleConfigurationFromRigid(q, qflex) == hresult_t::SUCCESS);
+    ASSERT_TRUE(qflex.isApprox(q));
+
+    auto visualData = pinocchio::GeometryData(model->visualModel_);
+    pinocchio::updateGeometryPlacements(model->pncModel_, pncData, model->visualModel_, visualData);
+
+    auto collisionData = pinocchio::GeometryData(model->collisionModel_);
+    pinocchio::updateGeometryPlacements(model->pncModel_, pncData, model->collisionModel_, collisionData);
+
+
+    // Add flexibility to joint and frame.
+    auto options = model->getOptions();
+    flexibilityConfig_t flexConfig;
+    vector3_t v = vector3_t::Constant(42);
+    flexConfig.push_back(flexibleJointData_t{"PendulumJoint", v, v, v});
+    flexConfig.push_back(flexibleJointData_t{"PendulumMassJoint", v, v, v});
+    boost::get<flexibilityConfig_t>(boost::get<configHolder_t>(options.at("dynamics")).at("flexibilityConfig")) = flexConfig;
+    model->setOptions(options);
+    model->reset();
+
+
+    ASSERT_TRUE(model->getFlexibleConfigurationFromRigid(q, qflex) == hresult_t::SUCCESS);
+    ASSERT_EQ(qflex.size(), q.size() + 8);
+
+    // Recompute frame, geometry and collision pose, and check that nothing has moved.
+    pinocchio::framesForwardKinematics(model->pncModel_, model->pncData_, qflex);
+    pinocchio::updateGeometryPlacements(model->pncModel_, model->pncData_, model->visualModel_, model->visualData_);
+    pinocchio::updateGeometryPlacements(model->pncModel_, model->pncData_, model->collisionModel_, model->collisionData_);
+
+    for (unsigned int i = 0; i < model->pncModelOrig_.frames.size(); i++)
+    {
+        long unsigned int flexId = model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name);
+        ASSERT_TRUE(pncData.oMf[i].toHomogeneousMatrix().isApprox(model->pncData_.oMf[flexId].toHomogeneousMatrix()));
+    }
+
+    for (unsigned int i = 0; i < model->visualData_.oMg.size(); i++)
+    {
+        ASSERT_TRUE(model->visualData_.oMg[i].toHomogeneousMatrix().isApprox(visualData.oMg[i].toHomogeneousMatrix()));
+    }
+
+    for (unsigned int i = 0; i < model->collisionData_.oMg.size(); i++)
+    {
+        ASSERT_TRUE(model->collisionData_.oMg[i].toHomogeneousMatrix().isApprox(collisionData.oMg[i].toHomogeneousMatrix()));
+    }
+
+
+}

--- a/core/unit/ModelTest.cc
+++ b/core/unit/ModelTest.cc
@@ -1,28 +1,25 @@
-// Test the sanity of the simulation engine.
-// The tests in this file verify that the behavior of a simulated system matches
-// real-world physics, and that no memory is allocated by Eigen during a simulation.
-// The test system is a double inverted pendulum.
 #include <gtest/gtest.h>
-
-#define EIGEN_RUNTIME_NO_MALLOC
 
 #include "jiminy/core/robot/Model.h"
 #include "jiminy/core/utilities/Helpers.h"
 #include "jiminy/core/Types.h"
 
-#include "pinocchio/algorithm/joint-configuration.hpp"
-#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 #include "pinocchio/algorithm/geometry.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
 
 using namespace jiminy;
 
-float64_t const TOLERANCE = 1e-9;
+
+class ModelTestFixture :
+    public testing::TestWithParam<bool> {
+};
 
 
-TEST(Model, CreateFlexible)
+TEST_P(ModelTestFixture, CreateFlexible)
 {
-    // Create a flexible model, and very that it makes sense.
+    // Create a flexible model, and verify that it makes sense.
+    bool const hasFreeflyer = GetParam();
 
     // Double pendulum model
     std::string const dataDirPath(UNIT_TEST_DATA_DIR);
@@ -30,14 +27,12 @@ TEST(Model, CreateFlexible)
 
     // All joints actuated.
     auto model = std::make_shared<Model>();
-    model->initialize(urdfPath, true, std::vector<std::string>(), true);
+    model->initialize(urdfPath, hasFreeflyer, std::vector<std::string>(), true);
 
     // We now have a rigid robot: perform rigid computation on this.
     auto q = pinocchio::randomConfiguration(model->pncModel_);
-    // Reset freeflyer to finite value.
-    q[0] = 42;
-    q[1] = 42;
-    q[2] = 42;
+    if (hasFreeflyer)
+        q.head<3>().setZero();
     auto pncData = pinocchio::Data(model->pncModel_);
     pinocchio::framesForwardKinematics(model->pncModel_, pncData, q);
 
@@ -52,11 +47,10 @@ TEST(Model, CreateFlexible)
     auto collisionData = pinocchio::GeometryData(model->collisionModel_);
     pinocchio::updateGeometryPlacements(model->pncModel_, pncData, model->collisionModel_, collisionData);
 
-
     // Add flexibility to joint and frame.
     auto options = model->getOptions();
     flexibilityConfig_t flexConfig;
-    vector3_t v = vector3_t::Constant(42);
+    vector3_t v = vector3_t::Ones();
     flexConfig.push_back(flexibleJointData_t{"PendulumJoint", v, v, v});
     flexConfig.push_back(flexibleJointData_t{"PendulumMassJoint", v, v, v});
     boost::get<flexibilityConfig_t>(boost::get<configHolder_t>(options.at("dynamics")).at("flexibilityConfig")) = flexConfig;
@@ -65,28 +59,31 @@ TEST(Model, CreateFlexible)
 
 
     ASSERT_TRUE(model->getFlexibleConfigurationFromRigid(q, qflex) == hresult_t::SUCCESS);
-    ASSERT_EQ(qflex.size(), q.size() + 8);
+    ASSERT_EQ(qflex.size(), q.size() + quaternion_t::Coefficients::RowsAtCompileTime * flexConfig.size());
 
     // Recompute frame, geometry and collision pose, and check that nothing has moved.
     pinocchio::framesForwardKinematics(model->pncModel_, model->pncData_, qflex);
     pinocchio::updateGeometryPlacements(model->pncModel_, model->pncData_, model->visualModel_, model->visualData_);
     pinocchio::updateGeometryPlacements(model->pncModel_, model->pncData_, model->collisionModel_, model->collisionData_);
 
-    for (unsigned int i = 0; i < model->pncModelOrig_.frames.size(); i++)
+    for (uint32_t i = 0; i < model->pncModelOrig_.frames.size(); i++)
     {
-        long unsigned int flexId = model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name);
+        uint32_t const flexId = static_cast<uint32_t>(model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name));
         ASSERT_TRUE(pncData.oMf[i].toHomogeneousMatrix().isApprox(model->pncData_.oMf[flexId].toHomogeneousMatrix()));
     }
 
-    for (unsigned int i = 0; i < model->visualData_.oMg.size(); i++)
+    for (uint32_t i = 0; i < model->visualData_.oMg.size(); i++)
     {
         ASSERT_TRUE(model->visualData_.oMg[i].toHomogeneousMatrix().isApprox(visualData.oMg[i].toHomogeneousMatrix()));
     }
 
-    for (unsigned int i = 0; i < model->collisionData_.oMg.size(); i++)
+    for (uint32_t i = 0; i < model->collisionData_.oMg.size(); i++)
     {
         ASSERT_TRUE(model->collisionData_.oMg[i].toHomogeneousMatrix().isApprox(collisionData.oMg[i].toHomogeneousMatrix()));
     }
-
-
 }
+
+INSTANTIATE_TEST_SUITE_P(ModelTests,
+                         ModelTestFixture,
+                         testing::Values(true, false));
+

--- a/core/unit/ModelTest.cc
+++ b/core/unit/ModelTest.cc
@@ -69,17 +69,17 @@ TEST_P(ModelTestFixture, CreateFlexible)
     for (uint32_t i = 0; i < model->pncModelOrig_.frames.size(); i++)
     {
         uint32_t const flexId = static_cast<uint32_t>(model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name));
-        ASSERT_TRUE(pncData.oMf[i].toHomogeneousMatrix().isApprox(model->pncData_.oMf[flexId].toHomogeneousMatrix()));
+        ASSERT_TRUE(pncData.oMf[i].isApprox(model->pncData_.oMf[flexId]));
     }
 
     for (uint32_t i = 0; i < model->visualData_.oMg.size(); i++)
     {
-        ASSERT_TRUE(model->visualData_.oMg[i].toHomogeneousMatrix().isApprox(visualData.oMg[i].toHomogeneousMatrix()));
+        ASSERT_TRUE(model->visualData_.oMg[i].isApprox(visualData.oMg[i]));
     }
 
     for (uint32_t i = 0; i < model->collisionData_.oMg.size(); i++)
     {
-        ASSERT_TRUE(model->collisionData_.oMg[i].toHomogeneousMatrix().isApprox(collisionData.oMg[i].toHomogeneousMatrix()));
+        ASSERT_TRUE(model->collisionData_.oMg[i].isApprox(collisionData.oMg[i]));
     }
 }
 

--- a/core/unit/ModelTest.cc
+++ b/core/unit/ModelTest.cc
@@ -53,8 +53,8 @@ TEST_P(ModelTestFixture, CreateFlexible)
     auto options = model->getOptions();
     flexibilityConfig_t flexConfig;
     vector3_t v = vector3_t::Ones();
-    flexConfig.emplace_back("PendulumJoint", v, v, v);
-    flexConfig.emplace_back("PendulumMassJoint", v, v, v);
+    flexConfig.push_back({"PendulumJoint", v, v, v});
+    flexConfig.push_back({"PendulumMassJoint", v, v, v});
     boost::get<flexibilityConfig_t>(boost::get<configHolder_t>(options.at("dynamics")).at("flexibilityConfig")) = flexConfig;
     model->setOptions(options);
     model->reset();

--- a/core/unit/ModelTest.cc
+++ b/core/unit/ModelTest.cc
@@ -32,7 +32,9 @@ TEST_P(ModelTestFixture, CreateFlexible)
     // We now have a rigid robot: perform rigid computation on this.
     auto q = pinocchio::randomConfiguration(model->pncModel_);
     if (hasFreeflyer)
+    {
         q.head<3>().setZero();
+    }
     auto pncData = pinocchio::Data(model->pncModel_);
     pinocchio::framesForwardKinematics(model->pncModel_, pncData, q);
 
@@ -51,8 +53,8 @@ TEST_P(ModelTestFixture, CreateFlexible)
     auto options = model->getOptions();
     flexibilityConfig_t flexConfig;
     vector3_t v = vector3_t::Ones();
-    flexConfig.push_back(flexibleJointData_t{"PendulumJoint", v, v, v});
-    flexConfig.push_back(flexibleJointData_t{"PendulumMassJoint", v, v, v});
+    flexConfig.emplace_back("PendulumJoint", v, v, v);
+    flexConfig.emplace_back("PendulumMassJoint", v, v, v);
     boost::get<flexibilityConfig_t>(boost::get<configHolder_t>(options.at("dynamics")).at("flexibilityConfig")) = flexConfig;
     model->setOptions(options);
     model->reset();
@@ -68,7 +70,7 @@ TEST_P(ModelTestFixture, CreateFlexible)
 
     for (uint32_t i = 0; i < model->pncModelOrig_.frames.size(); i++)
     {
-        uint32_t const flexId = static_cast<uint32_t>(model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name));
+        frameIndex_t const flexId = model->pncModel_.getFrameId(model->pncModelOrig_.frames[i].name);
         ASSERT_TRUE(pncData.oMf[i].isApprox(model->pncData_.oMf[flexId]));
     }
 

--- a/core/unit/data/branching_pendulum.urdf
+++ b/core/unit/data/branching_pendulum.urdf
@@ -1,0 +1,161 @@
+<?xml version="1.0" ?>
+<robot name="pendulum">
+    <link name="world">
+        <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+                <sphere radius="0.005"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="1000.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+
+    <joint name="PendulumJoint" type="revolute">
+      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+      <axis xyz="1 0 0"/>
+      <parent link="world"/>
+      <child link="PendulumArm"/>
+      <limit effort="1000" velocity="0" lower="-1000" upper="1000"/>
+    </joint>
+
+    <link name="PendulumArm">
+        <visual>
+            <origin xyz="0 0 0.5" rpy="0 0 0" />
+            <geometry>
+                <box size="0.01 0.01 1.0"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+
+
+    <joint name="PendulumMassJoint" type="fixed">
+      <origin xyz="0.0 0.0 1.0" rpy="0 0 0"/>
+      <parent link="PendulumArm"/>
+      <child link="PendulumMass"/>
+    </joint>
+    <link name="PendulumMass">
+        <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+                <sphere radius="0.06"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="1.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+
+    <joint name="SecondPendulumJoint" type="revolute">
+      <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+      <axis xyz="1 0 0"/>
+      <parent link="PendulumMass"/>
+      <child link="SecondPendulumArm"/>
+      <limit effort="1000" velocity="0" lower="-1000" upper="1000"/>
+    </joint>
+
+    <link name="SecondPendulumArm">
+        <visual>
+            <origin xyz="0 0 0.25" rpy="0 0 0" />
+            <geometry>
+                <box size="0.01 0.01 0.5"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+
+
+    <joint name="SecondPendulumMassJoint" type="fixed">
+      <origin xyz="0.0 0.0 0.5" rpy="0 0 0"/>
+      <parent link="SecondPendulumArm"/>
+      <child link="SecondPendulumMass"/>
+    </joint>
+    <link name="SecondPendulumMass">
+        <visual>
+            <origin xyz="0 0 0" rpy="0 0 0" />
+            <geometry>
+                <sphere radius="0.06"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="1.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+    <joint name="SecondBranchFirstJoint" type="revolute">
+      <origin xyz="0.1 0.0 0.0" rpy="0 0 0"/>
+      <axis xyz="1 0 0"/>
+      <parent link="PendulumArm"/>
+      <child link="SecondBranchFirstArm"/>
+      <limit effort="1000" velocity="0" lower="-1000" upper="1000"/>
+    </joint>
+    <link name="SecondBranchFirstArm">
+        <visual>
+            <origin xyz="0 0 0.25" rpy="0 0 0" />
+            <geometry>
+                <box size="0.01 0.01 0.5"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+    <joint name="SecondBranchSecondJoint" type="revolute">
+      <origin xyz="0.1 0.0 0.0" rpy="0 0 0"/>
+      <axis xyz="1 0 0"/>
+      <parent link="SecondBranchFirstArm"/>
+      <child link="SecondBranchSecondArm"/>
+      <limit effort="1000" velocity="0" lower="-1000" upper="1000"/>
+    </joint>
+    <link name="SecondBranchSecondArm">
+        <visual>
+            <origin xyz="0 0 0.25" rpy="0 0 0" />
+            <geometry>
+                <box size="0.01 0.01 0.5"/>
+            </geometry>
+            <material name="">
+                <color rgba="0.0 1.0 0.0 0.4"/>
+            </material>
+        </visual>
+        <inertial>
+            <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>
+            <mass value="0.0"/>
+            <inertia ixx="0.0" ixy="0.0" ixz="0.0" iyy="0.0" iyz="0.0" izz="0.0"/>
+        </inertial>
+    </link>
+</robot>


### PR DESCRIPTION
 - Incorrect placement of visual elements when adding flexibilites to a system with more than one limb.
 - [minor] The frame of the joint where the flexibility is attached was given the wrong parent, hence wrong placement.
 -  Add unit test to verify all this.