### PR TITLE
[core] Improve telemetry performance.

### DIFF
--- a/core/include/jiminy/core/control/AbstractController.h
+++ b/core/include/jiminy/core/control/AbstractController.h
@@ -76,12 +76,27 @@ namespace jiminy
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         ///
-        /// \brief      Dynamically registered a Eigen Vector to the telemetry.
+        /// \brief      Dynamically registered a scalar variable to the telemetry. It is the main entry 
+        ///             point for a user to log custom variables.
         ///
         /// \details    Internally, all it does is to store a reference to the variable, then it logs
         ///             its value periodically. There is no update mechanism what so ever nor safety
-        ///             check. So the user has to take care of the life span of the variable, and to
+        ///             check. The user has to take care of the life span of the variable, and to
         ///             update it manually whenever it is necessary to do so.
+        ///
+        /// \param[in]  fieldnames      Name of the variable. It will appear in the header of the log.
+        /// \param[in]  values          Variable to add to the telemetry.
+        ///
+        /// \return     Return code to determine whether the execution of the method was successful.
+        ///
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        template<typename T>
+        hresult_t registerVariable(std::string const & fieldname,
+                                   T           const & value);
+
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+        ///
+        /// \brief      Dynamically registered a Eigen Vector to the telemetry.
         ///
         /// \param[in]  fieldnames      Name of each element of the variable. It will appear in the header of the log.
         /// \param[in]  values          Eigen vector to add to the telemetry. It accepts non-contiguous temporary.
@@ -93,25 +108,6 @@ namespace jiminy
                                    Eigen::Ref<Eigen::Matrix<float64_t, -1, 1>, 0, Eigen::InnerStride<> > const & values);
         hresult_t registerVariable(std::vector<std::string> const & fieldnames,
                                    Eigen::Ref<Eigen::Matrix<int64_t, -1, 1>, 0, Eigen::InnerStride<> > const & values);
-
-        ///////////////////////////////////////////////////////////////////////////////////////////////
-        ///
-        /// \brief      Dynamically registered a float64 or int64 to the telemetry.
-        ///
-        /// \details    Internally, all it does is to store a reference to the variable, then it logs
-        ///             its value periodically. There is no update mechanism what so ever nor safety
-        ///             check. So the user has to take care of the life span of the variable, and to
-        ///             update it manually whenever it is necessary to do so.
-        ///
-        /// \param[in]  fieldnames      Name of the variable. It will appear in the header of the log.
-        /// \param[in]  values          Variable to add to the telemetry
-        ///
-        /// \return     Return code to determine whether the execution of the method was successful.
-        ///
-        ///////////////////////////////////////////////////////////////////////////////////////////////
-        template<typename T>
-        hresult_t registerVariable(std::string const & fieldname,
-                                   T           const & value);
 
         ///////////////////////////////////////////////////////////////////////////////////////////////
         ///

--- a/core/include/jiminy/core/engine/EngineMultiRobot.h
+++ b/core/include/jiminy/core/engine/EngineMultiRobot.h
@@ -667,6 +667,7 @@ namespace jiminy
         vector_aligned_t<forceVector_t> contactForcesPrev_;
         vector_aligned_t<forceVector_t> fPrev_;
         vector_aligned_t<motionVector_t> aPrev_;
+        std::vector<float64_t> energy_;
         std::shared_ptr<logData_t> logData_;
     };
 }

--- a/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
+++ b/core/include/jiminy/core/robot/PinocchioOverloadAlgorithms.h
@@ -41,10 +41,15 @@ namespace pinocchio_overload
     computeKineticEnergy(pinocchio::ModelTpl<Scalar, Options, JointCollectionTpl> const & model,
                          pinocchio::DataTpl<Scalar, Options, JointCollectionTpl>        & data,
                          Eigen::MatrixBase<ConfigVectorType>                      const & q,
-                         Eigen::MatrixBase<TangentVectorType>                     const & v)
+                         Eigen::MatrixBase<TangentVectorType>                     const & v,
+                         bool_t                                                   const & update_kinematics = true)
     {
-        (void) pinocchio::computeKineticEnergy(model, data, q, v);
-        data.kinetic_energy += 0.5 * (model.rotorInertia.array() * v.array().pow(2)).sum();
+        if (update_kinematics)
+        {
+            pinocchio::forwardKinematics(model, data, q, v);
+        }
+        (void) pinocchio::computeKineticEnergy(model, data);
+        data.kinetic_energy += 0.5 * (model.rotorInertia.array() * v.array().square()).sum();
         return data.kinetic_energy;
     }
 

--- a/core/include/jiminy/core/telemetry/TelemetryData.h
+++ b/core/include/jiminy/core/telemetry/TelemetryData.h
@@ -9,7 +9,6 @@
 
 #include <deque>
 
-#include "jiminy/core/telemetry/TelemetrySender.h"
 #include "jiminy/core/Macros.h"
 #include "jiminy/core/Types.h"
 

--- a/core/src/control/AbstractController.cc
+++ b/core/src/control/AbstractController.cc
@@ -150,7 +150,7 @@ namespace jiminy
                         // TODO Remove explicit `name` capture when moving to C++20
                         std::visit([&, & name = name](auto && arg)
                                    {
-                                       telemetrySender_.registerVariable(name, *arg);
+                                       telemetrySender_.registerVariable(name, arg);
                                    }, valuePtr);
                     }
                 }
@@ -231,14 +231,7 @@ namespace jiminy
     {
         if (isTelemetryConfigured_)
         {
-            for (auto const & [name, valuePtr] : registeredVariables_)
-            {
-                // TODO Remove explicit `name` capture when moving to C++20
-                std::visit([&, & name = name](auto && arg)
-                           {
-                               telemetrySender_.updateValue(name, *arg);
-                           }, valuePtr);
-            }
+            telemetrySender_.updateValues();
         }
     }
 

--- a/core/src/engine/EngineMultiRobot.cc
+++ b/core/src/engine/EngineMultiRobot.cc
@@ -877,7 +877,8 @@ namespace jiminy
                 systemIt->robot->pncModel_,
                 systemIt->robot->pncData_,
                 systemDataIt->state.q,
-                systemDataIt->state.v);
+                systemDataIt->state.v,
+                false);
             energy += pinocchio::computePotentialEnergy(
                 systemIt->robot->pncModel_,
                 systemIt->robot->pncData_);

--- a/core/src/robot/AbstractSensor.cc
+++ b/core/src/robot/AbstractSensor.cc
@@ -64,7 +64,7 @@ namespace jiminy
     {
         if (isTelemetryConfigured_)
         {
-            telemetrySender_.updateValue(getFieldnames(), get());
+            telemetrySender_.updateValues();
         }
     }
 

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/block_bases.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/block_bases.py
@@ -212,6 +212,10 @@ class BaseControllerBlock(
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the controller interface.
 
+        .. note::
+            No buffer is pre-allocated for the action since it is already done
+            by the parent environment.
+
         :param args: Extra arguments that may be useful for mixing
                      multiple inheritance through multiple inheritance.
         :param kwargs: Extra keyword arguments. See 'args'.
@@ -219,15 +223,9 @@ class BaseControllerBlock(
         # Call super to allow mixing interfaces through multiple inheritance
         super().__init__(*args, **kwargs)
 
-        # Allocate action buffer
-        self.action: ActT = zeros(self.action_space)
-
     def _setup(self) -> None:
         # Compute the update period
         self.control_dt = self.env.control_dt * self.update_ratio
-
-        # Set default action
-        fill(self.action, 0)
 
         # Make sure the controller period is lower than environment timestep
         assert self.control_dt <= self.env.step_dt, (

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/generic_bases.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/generic_bases.py
@@ -2,7 +2,6 @@
 specifically design for Jiminy engine, and defined as mixin classes. Any
 observer/controller block must inherit and implement those interfaces.
 """
-from collections import OrderedDict
 from abc import abstractmethod, ABC
 from typing import Dict, Any, TypeVar, Generic, no_type_check
 from typing_extensions import TypeAlias
@@ -193,12 +192,12 @@ class JiminyEnvInterface(
         # with the updated state of the agent.
         self.__is_observation_refreshed = True
 
-        # Store latest engine measurement for efficiency
-        self.__measurement: EngineObsType = OrderedDict(
+        # Store latest engine measurement for efficiency.
+        # Plain 'dict' is preferred over 'OrderedDict' for further speed-up.
+        self.__measurement: EngineObsType = dict(
             t=np.array(0.0),
-            states=OrderedDict(
-                agent=OrderedDict(q=np.array([]), v=np.array([]))),
-            measurements=OrderedDict(self.robot.sensors_data))
+            states=dict(agent=dict(q=np.array([]), v=np.array([]))),
+            measurements=dict(self.robot.sensors_data))
 
         # Call super to allow mixing interfaces through multiple inheritance
         super().__init__(*args, **kwargs)
@@ -249,7 +248,7 @@ class JiminyEnvInterface(
             measurement["t"][()] = t
             measurement["states"]["agent"]["q"] = q
             measurement["states"]["agent"]["v"] = v
-            dict.update(measurement["measurements"], sensors_data.items())
+            measurement["measurements"] = dict(sensors_data.items())
             self.refresh_observation(measurement)
 
         # Consider observation has been refreshed iif a simulation is running

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline_bases.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline_bases.py
@@ -219,7 +219,11 @@ class BasePipelineWrapper(
         if action is not self.action:
             self._copyto_action(action)
 
-        # Compute the next learning step
+        # Compute the next learning step.
+        # Note that forwarding 'self.env.action' enables skipping action update
+        # since it is only relevant for the most derived block. For the others,
+        # it will be done in 'compute_command' instead because it is unknown at
+        # this point and needs to be updated only if necessary.
         obs, reward, done, truncated, info = self.env.step(self.env.action)
 
         # Compute block's reward and add it to base one as long as it is worth

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/helpers.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/helpers.py
@@ -16,7 +16,7 @@ from .spaces import FieldNested, DataNested, zeros
 logger = logging.getLogger(__name__)
 
 
-@nb.jit(nopython=True, nogil=True, inline='always')
+@nb.jit(nopython=True, inline='always')
 def is_breakpoint(t: float, dt: float, eps: float) -> bool:
     """Check if 't' is multiple of 'dt' at a given precision 'eps'.
 

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -32,7 +32,7 @@ global_rng = np.random.default_rng()
 
 
 @no_type_check
-@nb.jit(nopython=True, nogil=True, inline='always')
+@nb.jit(nopython=True, inline='always')
 def _array_clip(value: np.ndarray,
                 low: Union[np.ndarray, SupportsFloat],
                 high: Union[np.ndarray, SupportsFloat]) -> np.ndarray:
@@ -49,7 +49,7 @@ def _array_clip(value: np.ndarray,
 
 
 @no_type_check
-@nb.jit(nopython=True, nogil=True, inline='always')
+@nb.jit(nopython=True, inline='always')
 def _array_contains(value: np.ndarray,
                     low: Union[np.ndarray, SupportsFloat],
                     high: Union[np.ndarray, SupportsFloat]) -> np.ndarray:

--- a/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/generic.py
+++ b/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/generic.py
@@ -7,7 +7,7 @@ import numpy as np
 import numba as nb
 
 
-@nb.jit(nopython=True, nogil=True, inline='always')
+@nb.jit(nopython=True, inline='always')
 def squared_norm_2(array: np.ndarray) -> float:
     """Fast implementation of the sum of squared array elements, optimized for
     small to medium size 1D arrays.


### PR DESCRIPTION
Atlas learning environment now has a real time factor of 55 on a single core.

* [core] Skip useless forward kinematics when updating telemetry.
* [core] Refactor telemetry sender to improve efficiency.
* [gym_jiminy/common] PID block supports ordering mismatch between sensors and motors.
* [gym_jiminy/common] Remove useless action buffer from ControllerBlock.
* [gym_jiminy/common] Speed-up refresh observation.
* [gym_jiminy/common] Speed up PID controller block.
* [gym_jiminy] Do not release GIL for small helpers.

Fixes https://github.com/duburcqa/jiminy/issues/33