### PR TITLE
Jiminy release 1.8.1

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -219,3 +219,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         packages-dir: wheelhouse
+        verify-metadata: false

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -229,3 +229,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         packages-dir: wheelhouse
+        verify-metadata: false

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -226,3 +226,4 @@ jobs:
       uses: pypa/gh-action-pypi-publish@v1.8.11
       with:
         packages-dir: wheelhouse
+        verify-metadata: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 cmake_minimum_required(VERSION 3.12.4)
 
 # Set the build version (specify a tweak version to indicated post-release if needed)
-set(BUILD_VERSION 1.8.0)
+set(BUILD_VERSION 1.8.1)
 
 # Set compatibility
 set(COMPATIBILITY_VERSION SameMinorVersion)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ python -m pip install --prefer-binary gym-jiminy[all]
 
 ## Excluding dependencies on Ubuntu 18+
 
-First, one must install the pre-compiled libraries of the dependencies. Most of them are available on `robotpkg` APT repository. Just run the bash script to install them automatically for Ubuntu 18 and upward. It should be straightforward to adapt it to any other distribution for which `robotpkg` is available.
+First, one must install the pre-compiled libraries of the dependencies. Most of them are available on `robotpkg` APT repository. Just run the bash script to install them automatically for Ubuntu 18 and upward. It should be straightforward to adapt it to any other distribution for which `robotpkg` is available. Note that if you plan to use a virtual environment (`venv`, `pyenv`, ...), you must install the Python dependencies manually using `pip`, i.e. `"wheel", "numpy>=1.21,<2.0"`.
 
 ```bash
 sudo env "PATH=$PATH" ./build_tools/easy_install_deps_ubuntu.sh
@@ -66,16 +66,16 @@ InstallDir="$RootDir/install"
 
 mkdir "$RootDir/build" "$InstallDir"
 cd "$RootDir/build"
-cmake "$RootDir" -DCMAKE_INSTALL_PREFIX="$InstallDir" \
-      -DBoost_NO_SYSTEM_PATHS=OFF \
+cmake "$RootDir" -DCMAKE_INSTALL_PREFIX="$InstallDir" -DCMAKE_PREFIX_PATH="/opt/openrobots/" \
+      -DPYTHON_EXECUTABLE="$(python3 -c 'import sys; sys.stdout.write(sys.executable)')" \
       -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
       -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 make install -j2
 ```
 
-## Including dependencies on Linux-based OS
+## Including dependencies on Unix-based OS
 
-### Prerequisites
+### Prerequisites (must be adapted to package managers other than `apt`)
 
 ```bash
 sudo apt install -y gnupg curl wget build-essential cmake doxygen graphviz

--- a/build_tools/build_install_deps_unix.sh
+++ b/build_tools/build_install_deps_unix.sh
@@ -61,7 +61,7 @@ if [ -z ${PYTHON_EXECUTABLE} ]; then
 fi
 
 ### Configure site-packages pythonic "symlink" pointing to install directory
-PYTHON_USER_SITELIB="$("${PYTHON_EXECUTABLE}" -m site --user-site)" || true
+PYTHON_USER_SITELIB="$("${PYTHON_EXECUTABLE}" -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" || true
 PYTHON_VERSION="$(${PYTHON_EXECUTABLE} -c "import sysconfig; print(sysconfig.get_config_var('py_version_short'))")"
 mkdir -p "${PYTHON_USER_SITELIB}"
 echo "${InstallDir}/lib/python${PYTHON_VERSION}/site-packages" > "${PYTHON_USER_SITELIB}/install_site.pth"

--- a/core/include/jiminy/core/macros.h
+++ b/core/include/jiminy/core/macros.h
@@ -65,18 +65,19 @@ namespace jiminy::internal
 */
 #define THROW_ERROR(exception, ...)                                                       \
     throw exception(                                                                      \
-        toString("In " FILE_LINE ": In ",                                                 \
+        toString("In ",                                                                   \
                  jiminy::internal::extractFunctionName(__func__, BOOST_CURRENT_FUNCTION), \
-                 ":\n\x1b[1;31merror:\x1b[0m ",                                           \
+                 " (" FILE_LINE "):\n",                                                   \
                  __VA_ARGS__))
 
 #ifdef NDEBUG
 #    define PRINT_WARNING(...)
 #else
 #    define PRINT_WARNING(...)                                                               \
-        std::cout << "In " FILE_LINE ": In "                                                 \
+        std::cout << "\x1b[1;93mWARNING\x1b[0m: In "                                         \
                   << jiminy::internal::extractFunctionName(__func__, BOOST_CURRENT_FUNCTION) \
-                  << ":\n\x1b[1;93mwarning:\x1b[0m " << toString(__VA_ARGS__) << std::endl
+                  << " (" FILE_LINE "):\n"                                                   \
+                  << toString(__VA_ARGS__) << std::endl
 #endif
 
 #endif  // JIMINY_MACRO_H

--- a/core/include/jiminy/core/stepper/lie_group.h
+++ b/core/include/jiminy/core/stepper/lie_group.h
@@ -76,6 +76,13 @@ namespace Eigen
         const DataType & a() const { return derived().a(); }
         DataType & a() { return derived().a(); }
 
+        StateDerivativeBase & absInPlace()
+        {
+            v().array() = v().array().abs();
+            a().array() = a().array().abs();
+            return *this;
+        }
+
         template<int p>
         RealScalar lpNorm() const;
         RealScalar norm() const { return lpNorm<2>(); };
@@ -1244,6 +1251,15 @@ namespace Eigen
         for (std::size_t i = 0; i < vector_.size(); ++i)                                      \
         {                                                                                     \
             vector_[i] += scale * vectorIn[i];                                                \
+        }                                                                                     \
+        return *this;                                                                         \
+    }                                                                                         \
+                                                                                              \
+    StateDerivativeVector & absInPlace()                                                      \
+    {                                                                                         \
+        for (std::size_t i = 0; i < vector_.size(); ++i)                                      \
+        {                                                                                     \
+            vector_[i].absInPlace();                                                          \
         }                                                                                     \
         return *this;                                                                         \
     }

--- a/core/include/jiminy/core/stepper/runge_kutta_dopri_stepper.h
+++ b/core/include/jiminy/core/stepper/runge_kutta_dopri_stepper.h
@@ -34,8 +34,14 @@ namespace jiminy
         /// \brief Stepper order, used to scale the error.
         inline constexpr double STEPPER_ORDER = 5.0;
         /// \brief Safety factor when updating the error, should be less than 1.
-        inline constexpr double SAFETY = 0.8;
-        /// \brief Miminum allowed relative step decrease.
+        ///
+        /// \details The larger the more conservative. More precisely, a small safety factor means
+        ///          that the step size will be increased less aggressively when the error is small
+        ///          and decreased more aggressively when the error is large.
+        inline constexpr double SAFETY = 0.9;
+        /// \brief Maximum acceptable error threshold below which step size is increased.
+        inline constexpr double ERROR_THRESHOLD = 0.5;
+        /// \brief Mininum allowed relative step decrease.
         inline constexpr double MIN_FACTOR = 0.2;
         /// \brief Maximum allowed relative step increase.
         inline constexpr double MAX_FACTOR = 5.0;

--- a/core/src/engine/engine_multi_robot.cc
+++ b/core/src/engine/engine_multi_robot.cc
@@ -1957,21 +1957,24 @@ namespace jiminy
                         hasDynamicsChanged = false;
                     }
 
-                    // Adjust stepsize to end up exactly at the next breakpoint
-                    dt = std::min(dt, tNext - t);
-                    if (dtLargest > SIMULATION_MIN_TIMESTEP)
+                    /* Adjust stepsize to end up exactly at the next breakpoint if it is reasonable
+                       to expect that integration will be successful, namely:
+                       - If the next breakpoint is closer than the estimated maximum step size
+                       OR
+                       - If the next breakpoint is farther but not so far away compared to the
+                         estimated maximum step size, AND the previous integration trial was
+                         successful. This last condition is essential to prevent infinite loop of
+                         slightly increasing the step size, failing to integrate, then try again
+                         and again until triggering maximum successive iteration failure exception.
+                         The current implementation is conservative and does not check that the
+                         previous failure was due to this stepsize adjustment procedure, but it is
+                         just a performance optimization trick, so it should not be a big deal. */
+                    const double dtResidualThr =
+                        std::min(SIMULATION_MIN_TIMESTEP, 0.1 * dtLargest);
+                    if (tNext - t < dt ||
+                        (successiveIterFailed == 0 && tNext - t < dt + dtResidualThr))
                     {
-                        if (tNext - (t + dt) < SIMULATION_MIN_TIMESTEP)
-                        {
-                            dt = tNext - t;
-                        }
-                    }
-                    else
-                    {
-                        if (tNext - (t + dt) < STEPPER_MIN_TIMESTEP)
-                        {
-                            dt = tNext - t;
-                        }
+                        dt = tNext - t;
                     }
 
                     /* Trying to reach multiples of STEPPER_MIN_TIMESTEP whenever possible. The
@@ -2555,7 +2558,12 @@ namespace jiminy
         const double dtMax = boost::get<double>(stepperOptions.at("dtMax"));
         if (SIMULATION_MAX_TIMESTEP + EPS < dtMax || dtMax < SIMULATION_MIN_TIMESTEP)
         {
-            THROW_ERROR(std::invalid_argument, "'dtMax' option is out of range.");
+            THROW_ERROR(std::invalid_argument,
+                        "'dtMax' option must bge in range [",
+                        SIMULATION_MIN_TIMESTEP,
+                        ", ",
+                        SIMULATION_MAX_TIMESTEP,
+                        "].");
         }
 
         // Make sure successiveIterFailedMax is strictly positive

--- a/core/src/engine/engine_multi_robot.cc
+++ b/core/src/engine/engine_multi_robot.cc
@@ -352,7 +352,7 @@ namespace jiminy
             // Compute intermediary quantities
             rot12.noalias() = oMf1.rotation().transpose() * oMf2.rotation();
             rotLog12 = pinocchio::log3(rot12, angle);
-            if (angle < 0.95 * M_PI)
+            if (angle > 0.95 * M_PI)
             {
                 THROW_ERROR(std::runtime_error,
                             "Relative angle between reference frames of viscoelastic "
@@ -3409,8 +3409,11 @@ namespace jiminy
 
             const Eigen::Map<const Eigen::Quaterniond> quat(q.segment<4>(positionIndex).data());
             const Eigen::Vector3d angleAxis = pinocchio::quaternion::log3(quat, angle);
-            assert((angle < 0.95 * M_PI) &&
-                   "Flexible joint angle must be smaller than 0.95 * pi.");
+            if (angle > 0.95 * M_PI)  // Angle is always positive
+            {
+                THROW_ERROR(std::runtime_error,
+                            "Flexible joint angle must be smaller than 0.95 * pi.");
+            }
             pinocchio::Jlog3(angle, angleAxis, rotJlog3);
             uInternal.segment<3>(velocityIndex) -=
                 rotJlog3 * (stiffness.array() * angleAxis.array()).matrix();

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/__init__.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/__init__.py
@@ -3,7 +3,6 @@
 from .spaces import (DataNested,
                      FieldNested,
                      get_bounds,
-                     sample,
                      zeros,
                      fill,
                      copyto,
@@ -20,7 +19,8 @@ from .spaces import (DataNested,
 from .helpers import (is_breakpoint,
                       is_nan,
                       get_fieldnames,
-                      register_variables)
+                      register_variables,
+                      sample)
 from .pipeline import build_pipeline, load_pipeline
 
 

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/helpers.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/helpers.py
@@ -2,7 +2,8 @@
 """
 import math
 import logging
-from typing import List, Sequence, Union, ValuesView
+from functools import partial
+from typing import Any, List, Sequence, ValuesView, Optional, Union, Protocol
 
 import gymnasium as gym
 import numpy as np
@@ -11,14 +12,25 @@ import numba as nb
 import jiminy_py.core as jiminy
 from jiminy_py import tree
 
-from .spaces import FieldNested, DataNested, zeros
+from .spaces import FieldNested, DataNested, ArrayOrScalar, zeros
 
 
 LOGGER = logging.getLogger(__name__)
 
+GLOBAL_RNG = np.random.default_rng()
+
 
 FieldNestedSequence = Sequence[Union['FieldNestedSequence', str]]
 FieldNestedList = List[Union[FieldNestedSequence, str]]
+
+
+class RandomDistribution(Protocol):
+    """Protocol to be satisfied when passing generic statistical distribution
+    callable to `sample` method.
+    """
+    def __call__(self, rg: np.random.Generator, *args: Any, **kwargs: Any
+                 ) -> ArrayOrScalar:
+        ...
 
 
 @nb.jit(nopython=True, cache=True, inline='always')
@@ -119,3 +131,89 @@ def register_variables(controller: jiminy.AbstractController,
         assert isinstance(fieldname, list), (
             f"'fieldname' ({fieldname}) should be a list of strings.")
         controller.register_variables(fieldname, value)
+
+
+def sample(low: Union[float, np.ndarray] = -1.0,
+           high: Union[float, np.ndarray] = 1.0,
+           dist: Union[str, RandomDistribution] = 'uniform',
+           scale: Union[float, np.ndarray] = 1.0,
+           enable_log_scale: bool = False,
+           shape: Optional[Sequence[int]] = None,
+           rg: Optional[np.random.Generator] = None
+           ) -> np.ndarray:
+    """Randomly sample values from a given distribution.
+
+    .. note:
+        If 'low', 'high', and 'scale' are floats, then the output is float if
+        'shape' is None, otherwise it has type `np.ndarray` and shape 'shape'.
+        Similarly, if any of 'low', 'high', and 'scale' are `np.ndarray`, then
+        its shape follows the broadcasting rules between these variables.
+
+    :param low: Lower value for bounded distribution, negative-side standard
+                deviation otherwise.
+                Optional: -1.0 by default.
+    :param high: Upper value for bounded distribution, positive-side standard
+                 deviation otherwise.
+                 Optional: 1.0 by default.
+    :param dist: The statistical from which to draw samples, either provided as
+                 a pre-defined string or a callable. For strings, then it must
+                 be a member function of `np.random.Generator` (only 'uniform'
+                 and 'normal' are supported for now). For callables, it must
+                 corresponds to a standardized distribution and satisfying
+                 `gym_jiminy.common.utils.RandomDistribution` protocol. This is
+                 especially useful for specifying custom parameters of complex
+                 distributions such as Beta. Using `functools.partial` is
+                 recommended, eg `partial(np.random.Generator.Beta, a=1, b=8)`.
+                 Optional: 'uniform' by default.
+    :param scale: Shrink the standard deviation of the distribution around the
+                  mean by this factor.
+                  Optional: No scaling by default?
+    :param enable_log_scale: The sampled values are power of 10.
+    :param shape: Enforce of the sampling shape. Only available if 'low',
+                  'high' and 'scale' are floats. `None` to disable.
+                  Optional: Disabled by default.
+    :param rg: Custom random number generator from which to draw samples.
+               Optional: Default to `np.random`.
+    """
+    # Compute mean and deviation from low and high arguments
+    mean = 0.5 * (low + high)
+    dev = 0.5 * scale * (high - low)
+
+    # Get sample shape.
+    # Better use dev than mean since it works even if only scale is array.
+    if isinstance(dev, np.ndarray):
+        if shape is None:
+            shape = dev.shape
+        else:
+            try:
+                shape = list(shape)
+                np.broadcast(np.empty(shape, dtype=[]), dev)
+            except ValueError as e:
+                raise ValueError(
+                    f"'shape' {shape} must be broadcast-able with 'low', "
+                    f"'high' and 'scale' {dev.shape} if specified.") from e
+
+    # Define "standardized" distribution callable if only its name was provided
+    if isinstance(dist, str):
+        if dist not in ('uniform', 'normal'):
+            raise NotImplementedError(
+                f"'{dist}' distribution type is not supported for now.")
+        dist_fn = getattr(np.random.Generator, dist)
+        if dist == 'uniform':
+            # The uniform distribution is NOT standardized by default
+            dist_fn = partial(dist_fn, low=-1.0, high=1.0)
+    else:
+        dist_fn = dist
+
+    # Generate samples from distribution.
+    # Make sure that the result is always returned as np.ndarray.
+    value = np.asarray(dist_fn(rg or GLOBAL_RNG, size=shape))
+
+    # Apply mean and standard deviation transformation
+    value = mean + dev * value
+
+    # Revert log scale if requested
+    if enable_log_scale:
+        value = 10 ** value
+
+    return value

--- a/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
@@ -141,9 +141,10 @@ class AcrobotJiminyEnv(BaseJiminyEnv[np.ndarray, np.ndarray]):
         # Call base implementation
         super()._setup()
 
-        # Increase stepper accuracy for time-continuous control
+        # Enforce fixed-timestep integrator.
+        # It ensures calling 'step' always takes the same amount of time.
         engine_options = self.simulator.engine.get_options()
-        engine_options["stepper"]["solver"] = "runge_kutta_4"
+        engine_options["stepper"]["odeSolver"] = "runge_kutta_4"
         engine_options["stepper"]["dtMax"] = CONTROL_DT
         self.simulator.engine.set_options(engine_options)
 

--- a/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
@@ -156,7 +156,7 @@ class CartPoleJiminyEnv(BaseJiminyEnv[np.ndarray, np.ndarray]):
 
         # OpenAI Gym implementation uses euler explicit integration scheme
         engine_options = self.simulator.engine.get_options()
-        engine_options["stepper"]["solver"] = "euler_explicit"
+        engine_options["stepper"]["odeSolver"] = "euler_explicit"
         engine_options["stepper"]["dtMax"] = CONTROL_DT
         self.simulator.engine.set_options(engine_options)
 


### PR DESCRIPTION
* [core] Error and warning reporting more consistent with Python. (#716)
* [core] Fix exception handling for visco-elastic coupling and internal flex forces. (#716)
* [core] Fix error estimation too optimistic for adaptive steppers. (#716)
* [core] Fix partially broken step adjustment optim that could lead to integration fail. (#721)
* [gym/common] Move 'sample' from 'spaces.py' to 'helpers.py'. (#721)
* [gym/zoo] Fix 'acrobot' and 'cartpole' envs not using wrong integrator. (#719)
* [misc] Do not verify metadata before pushing wheels on PyPi.
* [misc] Fix easy install doc. (#721)
* [misc] Fix support of virtual env ('venv', 'pyenv', ...) when building dependencies. (#721)