### PR TITLE
[core/python] Allow 'Model' instantiation from Python.

### DIFF
--- a/core/include/jiminy/core/engine/engine.h
+++ b/core/include/jiminy/core/engine/engine.h
@@ -8,7 +8,6 @@
 #include "jiminy/core/fwd.h"
 #include "jiminy/core/utilities/helpers.h"  // `Timer`
 #include "jiminy/core/utilities/random.h"   // `PCG32`
-#include "jiminy/core/robot/model.h"
 
 
 namespace jiminy
@@ -189,8 +188,6 @@ namespace jiminy
 
         uint32_t successiveSolveFailed{0};
         std::unique_ptr<AbstractConstraintSolver> constraintSolver{nullptr};
-        /// \brief Store copy of constraints register for fast access.
-        ConstraintTree constraints{};
         /// \brief Contact forces for each contact frames in local frame.
         ForceVector contactFrameForces{};
         /// \brief Contact forces for each geometries of each collision bodies in local frame.
@@ -702,7 +699,7 @@ namespace jiminy
         void computeContactDynamicsAtBody(
             const std::shared_ptr<Robot> & robot,
             const pinocchio::PairIndex & collisionPairIndex,
-            std::shared_ptr<AbstractConstraintBase> & contactConstraint,
+            const std::shared_ptr<AbstractConstraintBase> & contactConstraint,
             pinocchio::Force & fextLocal) const;
 
         /// \brief Compute the force resulting from ground contact on a given frame.
@@ -714,7 +711,7 @@ namespace jiminy
         void computeContactDynamicsAtFrame(
             const std::shared_ptr<Robot> & robot,
             pinocchio::FrameIndex frameIndex,
-            std::shared_ptr<AbstractConstraintBase> & collisionConstraint,
+            const std::shared_ptr<AbstractConstraintBase> & collisionConstraint,
             pinocchio::Force & fextLocal) const;
 
         /// \brief Compute the ground reaction force for a given normal direction and depth.
@@ -728,7 +725,6 @@ namespace jiminy
                             const Eigen::VectorXd & v,
                             Eigen::VectorXd & command);
         void computeInternalDynamics(const std::shared_ptr<Robot> & robot,
-                                     RobotData & robotData,
                                      double t,
                                      const Eigen::VectorXd & q,
                                      const Eigen::VectorXd & v,

--- a/core/include/jiminy/core/hardware/abstract_motor.h
+++ b/core/include/jiminy/core/hardware/abstract_motor.h
@@ -183,6 +183,8 @@ namespace jiminy
         /// \brief Reference to the last data buffer corresponding to the true effort of the motor.
         double & data();
 
+        bool isAttached() const;
+
     private:
         /// \brief Attach the sensor to a robot
         ///
@@ -203,14 +205,8 @@ namespace jiminy
         GenericConfig motorOptionsGeneric_{};
         /// \brief Flag to determine whether the controller has been initialized or not.
         bool isInitialized_{false};
-        /// \brief Flag to determine whether the motor is attached to a robot.
-        bool isAttached_{false};
         /// \brief Robot for which the command and internal dynamics.
         std::weak_ptr<const Robot> robot_{};
-        /// \brief Notify the robot that the configuration of the sensors have changed.
-        std::function<void(AbstractMotorBase &)> notifyRobot_{};
-        /// \brief Name of the motor.
-        std::string name_;
         /// \brief Index of the motor in the measurement buffer.
         std::size_t motorIndex_{0};
         std::string jointName_{};
@@ -222,6 +218,12 @@ namespace jiminy
         double armature_{0.0};
 
     private:
+        /// \brief Name of the motor.
+        std::string name_;
+        /// \brief Flag to determine whether the motor is attached to a robot.
+        bool isAttached_{false};
+        /// \brief Notify the robot that the configuration of the sensors have changed.
+        std::function<void(AbstractMotorBase &)> notifyRobot_{};
         /// \brief Shared data between every motors associated with the robot.
         MotorSharedStorage * sharedStorage_{nullptr};
     };

--- a/core/include/jiminy/core/hardware/abstract_sensor.hxx
+++ b/core/include/jiminy/core/hardware/abstract_sensor.hxx
@@ -165,8 +165,16 @@ namespace jiminy
         // Make sure the robot still exists
         if (robot_.expired())
         {
+            THROW_ERROR(bad_control_flow, "Robot has been deleted. Impossible to reset sensors.");
+        }
+
+        // Make sure that no simulation is already running
+        auto robot = robot_.lock();
+        if (robot && robot->getIsLocked())
+        {
             THROW_ERROR(bad_control_flow,
-                        "Robot has been deleted. Impossible to reset the sensors.");
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before resetting sensors.");
         }
 
         // Clear the shared data buffers

--- a/core/include/jiminy/core/hardware/basic_sensors.h
+++ b/core/include/jiminy/core/hardware/basic_sensors.h
@@ -57,6 +57,7 @@ namespace jiminy
 
         void initialize(const std::string & frameName);
 
+        void setOptions(const GenericConfig & sensorOptions) override;
         void refreshProxies() override;
 
         const std::string & getFrameName() const;
@@ -92,6 +93,7 @@ namespace jiminy
 
         void initialize(const std::string & frameName);
 
+        void setOptions(const GenericConfig & sensorOptions) override;
         void refreshProxies() override;
 
         const std::string & getFrameName() const;
@@ -130,6 +132,7 @@ namespace jiminy
 
         void initialize(const std::string & jointName);
 
+        void setOptions(const GenericConfig & sensorOptions) override;
         void refreshProxies() override;
 
         const std::string & getJointName() const;
@@ -166,6 +169,7 @@ namespace jiminy
 
         void initialize(const std::string & motorName);
 
+        void setOptions(const GenericConfig & sensorOptions) override;
         void refreshProxies() override;
 
         const std::string & getMotorName() const;

--- a/core/include/jiminy/core/robot/robot.h
+++ b/core/include/jiminy/core/robot/robot.h
@@ -74,6 +74,10 @@ namespace jiminy
         const Eigen::VectorXd & getMotorEfforts() const;
         double getMotorEffort(const std::string & motorName) const;
 
+        /// \warning It assumes that kinematic quantities have been updated previously and are
+        ///          consistent with the following input arguments. If not, one must call
+        ///          `pinocchio::forwardKinematics` and `pinocchio::updateFramePlacements`
+        ///          beforehand.
         void computeSensorMeasurements(double t,
                                        const Eigen::VectorXd & q,
                                        const Eigen::VectorXd & v,

--- a/core/include/jiminy/core/robot/robot.h
+++ b/core/include/jiminy/core/robot/robot.h
@@ -36,9 +36,10 @@ namespace jiminy
         auto shared_from_this() { return shared_from(this); }
         auto shared_from_this() const { return shared_from(this); }
 
-        void initialize(const pinocchio::Model & pinocchioModel,
-                        const pinocchio::GeometryModel & collisionModel,
-                        const pinocchio::GeometryModel & visualModel);
+        void initialize(
+            const pinocchio::Model & pinocchioModel,
+            const std::optional<pinocchio::GeometryModel> & collisionModel = std::nullopt,
+            const std::optional<pinocchio::GeometryModel> & visualModel = std::nullopt);
         void initialize(const std::string & urdfPath,
                         bool hasFreeflyer = true,
                         const std::vector<std::string> & meshPackageDirs = {},
@@ -72,13 +73,13 @@ namespace jiminy
                                  const Eigen::VectorXd & command);
         const Eigen::VectorXd & getMotorEfforts() const;
         double getMotorEffort(const std::string & motorName) const;
+
         void computeSensorMeasurements(double t,
                                        const Eigen::VectorXd & q,
                                        const Eigen::VectorXd & v,
                                        const Eigen::VectorXd & a,
                                        const Eigen::VectorXd & uMotor,
                                        const ForceVector & fExternal);
-
         SensorMeasurementTree getSensorMeasurements() const;
         Eigen::Ref<const Eigen::VectorXd> getSensorMeasurement(
             const std::string & sensorType, const std::string & sensorName) const;
@@ -99,8 +100,8 @@ namespace jiminy
         void dumpOptions(const std::string & filepath) const;
         void loadOptions(const std::string & filepath);
 
-        /// \remarks Those methods are not intended to be called manually. The Engine is taking
-        ///          care of it.
+        /// \remark This method does not have to be called manually before running a simulation.
+        ///         The Engine is taking care of it.
         virtual void reset(const uniform_random_bit_generator_ref<uint32_t> & g) override;
         virtual void configureTelemetry(std::shared_ptr<TelemetryData> telemetryData);
         void updateTelemetry();

--- a/core/include/jiminy/core/solver/constraint_solvers.h
+++ b/core/include/jiminy/core/solver/constraint_solvers.h
@@ -53,7 +53,7 @@ namespace jiminy
     public:
         explicit PGSSolver(const pinocchio::Model * model,
                            pinocchio::Data * data,
-                           ConstraintTree * constraints,
+                           const ConstraintTree * constraints,
                            double friction,
                            double torsion,
                            double tolAbs,

--- a/core/src/control/abstract_controller.cc
+++ b/core/src/control/abstract_controller.cc
@@ -23,6 +23,15 @@ namespace jiminy
            otherwise, it would be necessary to check consistency with system at engine level when
            calling reset. */
 
+        // Make sure that no simulation is already running
+        auto robotOld = robot_.lock();
+        if (robotOld && robotOld->getIsLocked())
+        {
+            THROW_ERROR(bad_control_flow,
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before re-initializing its controller.");
+        }
+
         // Make sure the robot is valid
         auto robot = robotIn.lock();
         if (!robot)
@@ -38,7 +47,6 @@ namespace jiminy
         // Make sure that the controller is not already bound to another robot
         if (isInitialized_)
         {
-            auto robotOld = robot_.lock();
             if (robotOld && robotOld.get() != robot.get())
             {
                 auto controllerOld = robotOld->getController().lock();
@@ -101,6 +109,15 @@ namespace jiminy
             THROW_ERROR(bad_control_flow, "The controller is not initialized.");
         }
 
+        // Make sure that no simulation is already running
+        auto robot = robot_.lock();
+        if (robot && robot->getIsLocked())
+        {
+            THROW_ERROR(bad_control_flow,
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before re-initializing its controller.");
+        }
+
         // Reset the telemetry buffer of dynamically registered quantities
         if (resetDynamicTelemetry)
         {
@@ -108,7 +125,6 @@ namespace jiminy
         }
 
         // Make sure the robot still exists
-        auto robot = robot_.lock();
         if (!robot)
         {
             THROW_ERROR(bad_control_flow, "Robot pointer expired or unset.");
@@ -232,6 +248,16 @@ namespace jiminy
 
     void AbstractController::setOptions(const GenericConfig & controllerOptions)
     {
+        // Make sure that no simulation is already running
+        auto robot = robot_.lock();
+        if (robot && robot->getIsLocked())
+        {
+            THROW_ERROR(bad_control_flow,
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before re-initializing its controller.");
+        }
+
+        // Set controller options
         controllerOptionsGeneric_ = controllerOptions;
         baseControllerOptions_ =
             std::make_unique<const ControllerOptions>(controllerOptionsGeneric_);

--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -845,9 +845,9 @@ namespace jiminy
         data.dhg.angular() += data.dhg.linear().cross(data.com[0]);
     }
 
-    void computeAllExtraTerms(std::vector<std::shared_ptr<Robot>> & robots,
-                              const vector_aligned_t<RobotData> & robotDataVec,
-                              vector_aligned_t<ForceVector> & f)
+    static void computeAllExtraTerms(std::vector<std::shared_ptr<Robot>> & robots,
+                                     const vector_aligned_t<RobotData> & robotDataVec,
+                                     vector_aligned_t<ForceVector> & f)
     {
         auto robotIt = robots.begin();
         auto robotDataIt = robotDataVec.begin();
@@ -858,10 +858,10 @@ namespace jiminy
         }
     }
 
-    void syncAccelerationsAndForces(const std::shared_ptr<Robot> & robot,
-                                    ForceVector & contactForces,
-                                    ForceVector & f,
-                                    MotionVector & a)
+    static void syncAccelerationsAndForces(const std::shared_ptr<Robot> & robot,
+                                           ForceVector & contactForces,
+                                           ForceVector & f,
+                                           MotionVector & a)
     {
         for (std::size_t i = 0; i < robot->getContactFrameNames().size(); ++i)
         {
@@ -875,10 +875,10 @@ namespace jiminy
         }
     }
 
-    void syncAllAccelerationsAndForces(const std::vector<std::shared_ptr<Robot>> & robots,
-                                       vector_aligned_t<ForceVector> & contactForces,
-                                       vector_aligned_t<ForceVector> & f,
-                                       vector_aligned_t<MotionVector> & a)
+    static void syncAllAccelerationsAndForces(const std::vector<std::shared_ptr<Robot>> & robots,
+                                              vector_aligned_t<ForceVector> & contactForces,
+                                              vector_aligned_t<ForceVector> & f,
+                                              vector_aligned_t<MotionVector> & a)
     {
         std::vector<std::shared_ptr<Robot>>::const_iterator robotIt = robots.begin();
         auto contactForceIt = contactForces.begin();
@@ -2846,7 +2846,6 @@ namespace jiminy
     // ================ Core physics utilities ================
     // ========================================================
 
-
     void Engine::computeForwardKinematics(std::shared_ptr<Robot> & robot,
                                           const Eigen::VectorXd & q,
                                           const Eigen::VectorXd & v,
@@ -3962,7 +3961,7 @@ namespace jiminy
         return std::const_pointer_cast<const LogData>(logData_);
     }
 
-    LogData readLogHdf5(const std::string & filename)
+    static LogData readLogHdf5(const std::string & filename)
     {
         LogData logData{};
 
@@ -4109,7 +4108,8 @@ namespace jiminy
                     "' not recognized. It must be either 'binary' or 'hdf5'.");
     }
 
-    void writeLogHdf5(const std::string & filename, const std::shared_ptr<const LogData> & logData)
+    static void writeLogHdf5(const std::string & filename,
+                             const std::shared_ptr<const LogData> & logData)
     {
         // Open HDF5 logfile
         std::unique_ptr<H5::H5File> file;

--- a/core/src/hardware/abstract_sensor.cc
+++ b/core/src/hardware/abstract_sensor.cc
@@ -77,6 +77,16 @@ namespace jiminy
 
     void AbstractSensorBase::setOptions(const GenericConfig & sensorOptions)
     {
+        // Make sure that no simulation is already running
+        auto robot = robot_.lock();
+        if (robot && robot->getIsLocked())
+        {
+            THROW_ERROR(bad_control_flow,
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before setting sensor options.");
+        }
+
+        // Set sensor options
         sensorOptionsGeneric_ = sensorOptions;
         baseSensorOptions_ = std::make_unique<const AbstractSensorOptions>(sensorOptionsGeneric_);
     }

--- a/core/src/hardware/basic_motors.cc
+++ b/core/src/hardware/basic_motors.cc
@@ -1,6 +1,5 @@
-#include <algorithm>
-
 #include "jiminy/core/utilities/helpers.h"
+#include "jiminy/core/robot/robot.h"
 
 #include "jiminy/core/hardware/basic_motors.h"
 
@@ -18,9 +17,21 @@ namespace jiminy
 
     void SimpleMotor::initialize(const std::string & jointName)
     {
+        // Make sure that no simulation is already running
+        // TODO: This check should be enforced by AbstractMotor somehow
+        auto robot = robot_.lock();
+        if (robot && robot->getIsLocked())
+        {
+            THROW_ERROR(bad_control_flow,
+                        "Robot already locked, probably because a simulation is running. "
+                        "Please stop it before refreshing motor proxies.");
+        }
+
+        // Update joint name
         jointName_ = jointName;
         isInitialized_ = true;
 
+        // Try refreshing proxies if possible, restore internals before throwing exception if not
         try
         {
             refreshProxies();

--- a/core/src/robot/model.cc
+++ b/core/src/robot/model.cc
@@ -49,7 +49,7 @@ namespace jiminy
     }
 
     template<typename T>
-    auto findImpl(T && constraints, const std::string & key, ConstraintNodeType node)
+    static auto findImpl(T && constraints, const std::string & key, ConstraintNodeType node)
     {
         // Determine return types based on argument constness
         constexpr bool isConst = std::is_const_v<std::remove_reference_t<T>>;

--- a/core/src/robot/robot.cc
+++ b/core/src/robot/robot.cc
@@ -45,7 +45,7 @@ namespace jiminy
     }
 
     template<typename... Args>
-    void initializeImpl(Robot & robot, Args... args)
+    static void initializeImpl(Robot & robot, Args... args)
     {
         // Make sure that no simulation is already running
         if (robot.getIsLocked())

--- a/core/src/solver/constraint_solvers.cc
+++ b/core/src/solver/constraint_solvers.cc
@@ -2,10 +2,11 @@
 #include "pinocchio/multibody/data.hpp"      // `pinocchio::Data`
 #include "pinocchio/algorithm/cholesky.hpp"  // `pinocchio::cholesky::`
 
-#include "jiminy/core/robot/pinocchio_overload_algorithms.h"
-#include "jiminy/core/constraints/abstract_constraint.h"
 #include "jiminy/core/utilities/random.h"
 #include "jiminy/core/utilities/helpers.h"
+#include "jiminy/core/constraints/abstract_constraint.h"
+#include "jiminy/core/robot/pinocchio_overload_algorithms.h"
+#include "jiminy/core/robot/model.h"
 
 #include "jiminy/core/solver/constraint_solvers.h"
 
@@ -22,7 +23,7 @@ namespace jiminy
 
     PGSSolver::PGSSolver(const pinocchio::Model * model,
                          pinocchio::Data * data,
-                         ConstraintTree * constraints,
+                         const ConstraintTree * constraints,
                          double friction,
                          double torsion,
                          double tolAbs,

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/mahony_filter.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/mahony_filter.py
@@ -244,18 +244,6 @@ class MahonyFilter(
             to kept the original estimate provided by Mahony Filter.
             See `remove_twist` and `update_twist` documentation for details.
             Optional: `None` by default.
-        :param twist_mode: Method used to compute twist part of twist-after-
-                           swing decomposition of the estimated orientation.
-                           It can be either 'none', 'leaky', 'default'. If
-                           'none', then the twist part is removed from mahony
-                           estimate. If 'leaky', it is removed and replaced
-                           by a leaky integrator estimate with given time
-                           constant. This choice is recommended because the
-                           twist is not observable by the accelerometer, so
-                           its value comes from the sole integration of the
-                           gyroscope, which is drifting and therefore
-                           unreliable.
-                           Optional: `False` by default.
         :param exact_init: Whether to initialize orientation estimate using
                            accelerometer measurements or ground truth. `False`
                            is not recommended because the robot is often
@@ -284,13 +272,13 @@ class MahonyFilter(
 
         # Keep track of how the twist must be computed
         self.twist_time_constant_inv: Optional[float]
-        if twist_time_constant is not None:
+        if twist_time_constant is None:
+            self.twist_time_constant_inv = None
+        else:
             if twist_time_constant > 0.0:
                 self.twist_time_constant_inv = 1.0 / twist_time_constant
             else:
                 self.twist_time_constant_inv = float("inf")
-        else:
-            self.twist_time_constant_inv = None
         self._remove_twist = self.twist_time_constant_inv is not None
         self._update_twist = (
             self.twist_time_constant_inv is not None and

--- a/python/jiminy_pywrap/include/jiminy/python/constraints.h
+++ b/python/jiminy_pywrap/include/jiminy/python/constraints.h
@@ -6,7 +6,7 @@
 
 namespace jiminy::python
 {
-    void JIMINY_DLLAPI exposeConstraint();
+    void JIMINY_DLLAPI exposeConstraints();
     void JIMINY_DLLAPI exposeConstraintTree();
 }
 

--- a/python/jiminy_pywrap/include/jiminy/python/motors.h
+++ b/python/jiminy_pywrap/include/jiminy/python/motors.h
@@ -7,7 +7,7 @@
 namespace jiminy::python
 {
     void JIMINY_DLLAPI exposeAbstractMotor();
-    void JIMINY_DLLAPI exposeSimpleMotor();
+    void JIMINY_DLLAPI exposeBasicMotors();
 }
 
 #endif  // MOTORS_PYTHON_H

--- a/python/jiminy_pywrap/include/jiminy/python/utilities.h
+++ b/python/jiminy_pywrap/include/jiminy/python/utilities.h
@@ -66,12 +66,6 @@ namespace jiminy::python
         return pythonExceptionTypeObj;
     }
 
-#define BOOST_PYTHON_VISITOR_EXPOSE(class) \
-    void expose##class()                   \
-    {                                      \
-        Py##class##Visitor::expose();      \
-    }
-
     template<typename T>
     struct get_signature_impl;
 

--- a/python/jiminy_pywrap/src/functors.cc
+++ b/python/jiminy_pywrap/src/functors.cc
@@ -7,7 +7,7 @@ namespace jiminy::python
 {
     namespace bp = boost::python;
 
-    // ************************** FunPyWrapper ******************************
+    // ************************************** FunPyWrapper ************************************* //
 
     template<>
     typename InternalStorageType<pinocchio::Force>::type
@@ -22,30 +22,10 @@ namespace jiminy::python
         return (new pinocchio::Force(Vector6d::Zero()));
     }
 
-    // **************************** PyHeightmapFunctionVisitor *****************************
+    // *********************************** HeightmapFunction *********************************** //
 
-    struct PyHeightmapFunctionVisitor : public bp::def_visitor<PyHeightmapFunctionVisitor>
+    namespace internal::heightmap_function
     {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            // clang-format off
-            cl
-                .def("__init__", bp::make_constructor(&PyHeightmapFunctionVisitor::factory,
-                                 bp::default_call_policies(),
-                                (bp::arg("heightmap_function"),
-                                 bp::arg("heightmap_type")=heightmapType_t::GENERIC)))
-                .def("__call__", &PyHeightmapFunctionVisitor::eval,
-                                 (bp::arg("self"), "position"))
-                .ADD_PROPERTY_GET_WITH_POLICY("py_function",
-                                              &PyHeightmapFunctionVisitor::getPyFun,
-                                              bp::return_value_policy<bp::return_by_value>());
-                ;
-            // clang-format on
-        }
-
         static bp::tuple eval(HeightmapFunction & self, const Eigen::Vector2d & position)
         {
             double height;
@@ -69,16 +49,20 @@ namespace jiminy::python
         {
             return std::make_shared<HeightmapFunction>(HeightmapFunPyWrapper(objPy, objType));
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<HeightmapFunction,
-                       std::shared_ptr<HeightmapFunction>>("HeightmapFunction", bp::no_init)
-                .def(PyHeightmapFunctionVisitor());
-            // clang-format on
-        }
-    };
-
-    BOOST_PYTHON_VISITOR_EXPOSE(HeightmapFunction)
+    void exposeHeightmapFunction()
+    {
+        bp::class_<HeightmapFunction, std::shared_ptr<HeightmapFunction>>("HeightmapFunction",
+                                                                          bp::no_init)
+            .def("__init__",
+                 bp::make_constructor(&internal::heightmap_function::factory,
+                                      bp::default_call_policies(),
+                                      (bp::arg("heightmap_function"),
+                                       bp::arg("heightmap_type") = heightmapType_t::GENERIC)))
+            .def("__call__", &internal::heightmap_function::eval, (bp::arg("self"), "position"))
+            .ADD_PROPERTY_GET_WITH_POLICY("py_function",
+                                          &internal::heightmap_function::getPyFun,
+                                          bp::return_value_policy<bp::return_by_value>());
+    }
 }

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -104,7 +104,7 @@ namespace jiminy::python
             .def("__init__", bp::make_constructor(&makePCG32FromSeedSed,
                              bp::default_call_policies(),
                              (bp::arg("seed_seq"))))
-            .def("__call__", &PCG32::operator(), bp::args("self"))
+            .def("__call__", &PCG32::operator(), (bp::arg("self")))
             .def("seed", &seedPCG32FromSeedSed, (bp::arg("self"), "seed_seq"))
             .add_static_property(
                 "min", &PCG32::min, getPropertySignaturesWithDoc(nullptr, &PCG32::min).c_str())

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -93,81 +93,6 @@ namespace jiminy::python
 
 #undef GENERIC_DISTRIBUTION_WRAPPER
 
-    template<typename R, typename F, typename... Args>
-    R convertGeneratorToPythonAndInvoke(F callable, bp::object generatorPy, Args &&... args)
-    {
-        // First, check if the provided generator can be implicitly converted
-        bp::extract<uniform_random_bit_generator_ref<uint32_t>> generatorPyGetter(generatorPy);
-        if (generatorPyGetter.check())
-        {
-            return callable(generatorPyGetter(), std::forward<Args>(args)...);
-        }
-
-        // If not, assuming it is a numpy random generator and try to extract the raw function
-        bp::object ctypes_addressof = bp::import("ctypes").attr("addressof");
-        bp::object next_uint32_ctype = generatorPy.attr("ctypes").attr("next_uint32");
-        uintptr_t next_uint32_addr = bp::extract<uintptr_t>(ctypes_addressof(next_uint32_ctype));
-        auto next_uint32 = *reinterpret_cast<uint32_t (**)(void *)>(next_uint32_addr);
-        bp::object state_ctype = generatorPy.attr("ctypes").attr("state_address");
-        void * state_ptr = reinterpret_cast<void *>(bp::extract<uintptr_t>(state_ctype)());
-
-        return callable([state_ptr, next_uint32]() -> uint32_t { return next_uint32(state_ptr); },
-                        std::forward<Args>(args)...);
-    }
-
-    template<typename Signature, typename>
-    class ConvertGeneratorToPythonAndInvoke;
-
-    template<typename R, typename Generator, typename... Args>
-    class ConvertGeneratorToPythonAndInvoke<R(Generator, Args...), void>
-    {
-    public:
-        ConvertGeneratorToPythonAndInvoke(R (*func)(Generator, Args...)) :
-        func_{func}
-        {
-        }
-
-        R operator()(bp::object generatorPy, Args... argsPy)
-        {
-            return convertGeneratorToPythonAndInvoke<R, R (*)(Generator, Args...), Args...>(
-                func_, generatorPy, std::forward<Args>(argsPy)...);
-        }
-
-    private:
-        R (*func_)(Generator, Args...);
-    };
-
-    template<typename R, typename... Args>
-    ConvertGeneratorToPythonAndInvoke(R (*)(Args...))
-        -> ConvertGeneratorToPythonAndInvoke<R(Args...), void>;
-
-    template<typename T, typename R, typename Generator, typename... Args>
-    class ConvertGeneratorToPythonAndInvoke<R(Generator, Args...), T>
-    {
-    public:
-        ConvertGeneratorToPythonAndInvoke(R (T::*memFun)(Generator, Args...)) :
-        memFun_{memFun}
-        {
-        }
-
-        R operator()(T & obj, bp::object generatorPy, Args... argsPy)
-        {
-            auto callable = [&obj, memFun = memFun_](Generator generator, Args... args) -> R
-            {
-                return (obj.*memFun)(generator, args...);
-            };
-            return convertGeneratorToPythonAndInvoke<R, decltype(callable), Args...>(
-                callable, generatorPy, std::forward<Args>(argsPy)...);
-        }
-
-    private:
-        R (T::*memFun_)(Generator, Args...);
-    };
-
-    template<typename T, typename R, typename... Args>
-    ConvertGeneratorToPythonAndInvoke(R (T::*)(Args...))
-        -> ConvertGeneratorToPythonAndInvoke<R(Args...), T>;
-
     void exposeGenerators()
     {
         // clang-format off
@@ -188,15 +113,15 @@ namespace jiminy::python
 
         bp::implicitly_convertible<PCG32, uniform_random_bit_generator_ref<uint32_t>>();
 
-#define BIND_GENERIC_DISTRIBUTION(dist, arg1, arg2)                                          \
-        bp::def(#dist, makeFunction(                                                         \
-            ConvertGeneratorToPythonAndInvoke(&dist##FromStackedArgs),                       \
-            bp::default_call_policies(),                                                     \
-            (bp::arg("generator"), #arg1, #arg2)));                                          \
-        bp::def(#dist, makeFunction(                                                         \
-            ConvertGeneratorToPythonAndInvoke(&dist##FromSize),                              \
-            bp::default_call_policies(),                                                     \
-            (bp::arg("generator"), bp::arg(#arg1) = 0.0F, bp::arg(#arg2) = 1.0F,             \
+#define BIND_GENERIC_DISTRIBUTION(dist, arg1, arg2)                               \
+        bp::def(#dist, makeFunction(                                              \
+            ConvertGeneratorFromPythonAndInvoke(&dist##FromStackedArgs),          \
+            bp::default_call_policies(),                                          \
+            (bp::arg("generator"), #arg1, #arg2)));                               \
+        bp::def(#dist, makeFunction(                                              \
+            ConvertGeneratorFromPythonAndInvoke(&dist##FromSize),                 \
+            bp::default_call_policies(),                                          \
+            (bp::arg("generator"), bp::arg(#arg1) = 0.0F, bp::arg(#arg2) = 1.0F,  \
              bp::arg("size") = bp::object())));
 
     BIND_GENERIC_DISTRIBUTION(uniform, lo, hi)
@@ -205,7 +130,7 @@ namespace jiminy::python
 #undef BIND_GENERIC_DISTRIBUTION
 
         // Must be declared last to take precedence over generic declaration with default values
-        bp::def("uniform", makeFunction(ConvertGeneratorToPythonAndInvoke(
+        bp::def("uniform", makeFunction(ConvertGeneratorFromPythonAndInvoke(
             static_cast<
                 float (*)(const uniform_random_bit_generator_ref<uint32_t> &)
             >(&uniform)),
@@ -220,7 +145,7 @@ namespace jiminy::python
             .def("__call__", &PeriodicGaussianProcess::operator(),
                              (bp::arg("self"), bp::arg("time")))
             .def("reset", makeFunction(
-                          ConvertGeneratorToPythonAndInvoke(&PeriodicGaussianProcess::reset),
+                          ConvertGeneratorFromPythonAndInvoke(&PeriodicGaussianProcess::reset),
                           bp::default_call_policies(),
                           (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET_WITH_POLICY("wavelength",
@@ -238,7 +163,7 @@ namespace jiminy::python
             .def("__call__", &PeriodicFourierProcess::operator(),
                              (bp::arg("self"), bp::arg("time")))
             .def("reset", makeFunction(
-                          ConvertGeneratorToPythonAndInvoke(&PeriodicFourierProcess::reset),
+                          ConvertGeneratorFromPythonAndInvoke(&PeriodicFourierProcess::reset),
                           bp::default_call_policies(),
                           (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET_WITH_POLICY("wavelength",
@@ -254,7 +179,7 @@ namespace jiminy::python
             .def("__call__", &AbstractPerlinProcess::operator(),
                              (bp::arg("self"), "time"))
             .def("reset", makeFunction(
-                          ConvertGeneratorToPythonAndInvoke(&AbstractPerlinProcess::reset),
+                          ConvertGeneratorFromPythonAndInvoke(&AbstractPerlinProcess::reset),
                           bp::default_call_policies(),
                           (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET_WITH_POLICY("wavelength",

--- a/python/jiminy_pywrap/src/module.cc
+++ b/python/jiminy_pywrap/src/module.cc
@@ -106,12 +106,12 @@ namespace jiminy::python
 
         // Expose structs and classes
         exposeSensorMeasurementTree();
-        exposeConstraint();
+        exposeConstraints();
         exposeConstraintTree();
         exposeModel();
         exposeRobot();
         exposeAbstractMotor();
-        exposeSimpleMotor();
+        exposeBasicMotors();
         exposeAbstractSensor();
         exposeBasicSensors();
         exposeAbstractController();

--- a/python/jiminy_pywrap/src/motors.cc
+++ b/python/jiminy_pywrap/src/motors.cc
@@ -10,104 +10,66 @@ namespace jiminy::python
 {
     namespace bp = boost::python;
 
-    // ***************************** PyAbstractMotorVisitor ***********************************
+    // ************************************* AbstractMotor ************************************* //
 
-    struct PyAbstractMotorVisitor : public bp::def_visitor<PyAbstractMotorVisitor>
+    namespace internal::abstract_motor
     {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            // clang-format off
-            cl
-                .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
-                                              &AbstractMotorBase::getIsInitialized,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("name",
-                                              &AbstractMotorBase::getName,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("index",
-                                              &AbstractMotorBase::getIndex,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("joint_name",
-                                              &AbstractMotorBase::getJointName,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("joint_index",
-                                              &AbstractMotorBase::getJointIndex,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("joint_type",
-                                              &AbstractMotorBase::getJointType,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("joint_position_index",
-                                              &AbstractMotorBase::getJointPositionIndex,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("joint_velocity_index",
-                                              &AbstractMotorBase::getJointVelocityIndex,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("command_limit",
-                                              &AbstractMotorBase::getCommandLimit,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("armature",
-                                              &AbstractMotorBase::getArmature,
-                                              bp::return_value_policy<bp::return_by_value>())
-
-                .def("set_options", &PyAbstractMotorVisitor::setOptions)
-                .def("get_options", &AbstractMotorBase::getOptions)
-                ;
-            // clang-format on
-        }
-
-    public:
         static void setOptions(AbstractMotorBase & self, const bp::dict & configPy)
         {
             GenericConfig config = self.getOptions();
             convertFromPython(configPy, config);
             return self.setOptions(config);
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<AbstractMotorBase,
-                       std::shared_ptr<AbstractMotorBase>,
-                       boost::noncopyable>("AbstractMotor", bp::no_init)
-                .def(PyAbstractMotorVisitor());
-            // clang-format on
-        }
-    };
-
-    BOOST_PYTHON_VISITOR_EXPOSE(AbstractMotor)
-
-    // ***************************** PySimpleMotorVisitor ***********************************
-
-    struct PySimpleMotorVisitor : public bp::def_visitor<PySimpleMotorVisitor>
+    void exposeAbstractMotor()
     {
-    public:
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            using TMotor = typename PyClass::wrapped_type;
+        bp::class_<AbstractMotorBase, std::shared_ptr<AbstractMotorBase>, boost::noncopyable>(
+            "AbstractMotor", bp::no_init)
+            .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
+                                          &AbstractMotorBase::getIsInitialized,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("name",
+                                          &AbstractMotorBase::getName,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("index",
+                                          &AbstractMotorBase::getIndex,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("joint_name",
+                                          &AbstractMotorBase::getJointName,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("joint_index",
+                                          &AbstractMotorBase::getJointIndex,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("joint_type",
+                                          &AbstractMotorBase::getJointType,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("joint_position_index",
+                                          &AbstractMotorBase::getJointPositionIndex,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("joint_velocity_index",
+                                          &AbstractMotorBase::getJointVelocityIndex,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("command_limit",
+                                          &AbstractMotorBase::getCommandLimit,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("armature",
+                                          &AbstractMotorBase::getArmature,
+                                          bp::return_value_policy<bp::return_by_value>())
 
-            // clang-format off
-            cl
-                .def("initialize", &TMotor::initialize)
-                ;
-            // clang-format on
-        }
+            .def("set_options", &internal::abstract_motor::setOptions)
+            .def("get_options", &AbstractMotorBase::getOptions);
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<SimpleMotor, bp::bases<AbstractMotorBase>,
-                       std::shared_ptr<SimpleMotor>,
-                       boost::noncopyable>("SimpleMotor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "motor_name")))
-                .def(PySimpleMotorVisitor());
-            // clang-format on
-        }
-    };
+    // ************************************** BasicMotors ************************************** //
 
-    BOOST_PYTHON_VISITOR_EXPOSE(SimpleMotor)
+    void exposeBasicMotors()
+    {
+        bp::class_<SimpleMotor,
+                   bp::bases<AbstractMotorBase>,
+                   std::shared_ptr<SimpleMotor>,
+                   boost::noncopyable>(
+            "SimpleMotor", bp::init<const std::string &>((bp::arg("self"), "motor_name")))
+            .def("initialize", &SimpleMotor::initialize);
+    }
 }

--- a/python/jiminy_pywrap/src/robot.cc
+++ b/python/jiminy_pywrap/src/robot.cc
@@ -16,217 +16,41 @@ namespace jiminy::python
 {
     namespace bp = boost::python;
 
-    // ***************************** PyModelVisitor ***********************************
+    // ***************************************** Model ***************************************** //
+
+    template<typename T>
+    static void initialize(T & self,
+                           const std::string & urdfPath,
+                           bool hasFreeflyer,
+                           const bp::object & meshPackageDirsPy,
+                           bool loadVisualMeshes)
+    {
+        auto meshPackageDirs = convertFromPython<std::vector<std::string>>(meshPackageDirsPy);
+        return self.initialize(urdfPath, hasFreeflyer, meshPackageDirs, loadVisualMeshes);
+    }
+
+    template<typename T>
+    static void initializeFromModels(T & self,
+                                     const pinocchio::Model & pinocchioModel,
+                                     const bp::object & collisionModelPy,
+                                     const bp::object & visualModelPy)
+    {
+        std::optional<pinocchio::GeometryModel> collisionModel;
+        if (!collisionModelPy.is_none())
+        {
+            collisionModel.emplace(
+                bp::extract<const pinocchio::GeometryModel &>(collisionModelPy));
+        }
+        std::optional<pinocchio::GeometryModel> visualModel;
+        if (!visualModelPy.is_none())
+        {
+            visualModel.emplace(bp::extract<const pinocchio::GeometryModel &>(visualModelPy));
+        }
+        return self.initialize(pinocchioModel, collisionModel, visualModel);
+    }
 
     namespace internal::model
     {
-        template<typename T>
-        void initialize(T & self,
-                        const std::string & urdfPath,
-                        bool hasFreeflyer,
-                        const bp::object & meshPackageDirsPy,
-                        bool loadVisualMeshes)
-        {
-            auto meshPackageDirs = convertFromPython<std::vector<std::string>>(meshPackageDirsPy);
-            return self.initialize(urdfPath, hasFreeflyer, meshPackageDirs, loadVisualMeshes);
-        }
-
-        template<typename T>
-        void initializeFromModels(T & self,
-                                  const pinocchio::Model & pinocchioModel,
-                                  const bp::object & collisionModelPy,
-                                  const bp::object & visualModelPy)
-        {
-            std::optional<pinocchio::GeometryModel> collisionModel;
-            if (!collisionModelPy.is_none())
-            {
-                collisionModel.emplace(
-                    bp::extract<const pinocchio::GeometryModel &>(collisionModelPy));
-            }
-            std::optional<pinocchio::GeometryModel> visualModel;
-            if (!visualModelPy.is_none())
-            {
-                visualModel.emplace(bp::extract<const pinocchio::GeometryModel &>(visualModelPy));
-            }
-            return self.initialize(pinocchioModel, collisionModel, visualModel);
-        }
-    }
-
-    struct PyModelVisitor : public bp::def_visitor<PyModelVisitor>
-    {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            // clang-format off
-            cl
-                .def("initialize", &internal::model::initialize<typename PyClass::wrapped_type>,
-                                   (bp::arg("self"), "urdf_path",
-                                    bp::arg("has_freeflyer") = false,
-                                    bp::arg("mesh_package_dirs") = bp::list(),
-                                    bp::arg("load_visual_meshes") = false))
-                .def("initialize", &internal::model::initializeFromModels<typename PyClass::wrapped_type>,
-                                   (bp::arg("self"), "pinocchio_model",
-                                    bp::arg("collision_model") = bp::object(),
-                                    bp::arg("visual_model") = bp::object()))
-
-                .def("reset", makeFunction(
-                              ConvertGeneratorFromPythonAndInvoke(&Model::reset),
-                              bp::default_call_policies(),
-                              (bp::arg("self"), "generator")))
-
-                .def("add_frame",
-                     static_cast<
-                         void (Model::*)(const std::string &, const std::string &, const pinocchio::SE3 &)
-                     >(&Model::addFrame),
-                     (bp::arg("self"), "frame_name", "parent_body_name", "frame_placement"))
-                .def("remove_frame", &Model::removeFrame,
-                                     (bp::arg("self"), "frame_name"))
-                .def("add_collision_bodies", &PyModelVisitor::addCollisionBodies,
-                                             (bp::arg("self"),
-                                              bp::arg("body_names") = bp::list(),
-                                              bp::arg("ignore_meshes") = false))
-                .def("remove_collision_bodies", &PyModelVisitor::removeCollisionBodies,
-                                                (bp::arg("self"), "body_names"))
-                .def("add_contact_points", &PyModelVisitor::addContactPoints,
-                                           (bp::arg("self"),
-                                            bp::arg("frame_names") = bp::list()))
-                .def("remove_contact_points", &PyModelVisitor::removeContactPoints,
-                                              (bp::arg("self"), "frame_names"))
-
-                .def("add_constraint",
-                     static_cast<
-                         void (Model::*)(const std::string &, const std::shared_ptr<AbstractConstraintBase> &)
-                     >(&Model::addConstraint),
-                     (bp::arg("self"), "name", "constraint"))
-                .def("remove_constraint",
-                     static_cast<
-                         void (Model::*)(const std::string &)
-                     >(&Model::removeConstraint),
-                     (bp::arg("self"), "name"))
-                .def("get_constraint",
-                     static_cast<
-                         std::shared_ptr<AbstractConstraintBase> (Model::*)(const std::string &)
-                     >(&Model::getConstraint),
-                     (bp::arg("self"), "constraint_name"))
-                .def("exist_constraint", &Model::existConstraint,
-                                         (bp::arg("self"), "constraint_name"))
-                .ADD_PROPERTY_GET("has_constraints", &Model::hasConstraints)
-                .ADD_PROPERTY_GET_WITH_POLICY("constraints",
-                                              &Model::getConstraints,
-                                              bp::return_value_policy<result_converter<false>>())
-                .def("get_constraints_jacobian_and_drift", &PyModelVisitor::getConstraintsJacobianAndDrift)
-                .def("compute_constraints", &Model::computeConstraints,
-                                            (bp::arg("self"), "q", "v"))
-
-                .def("get_flexible_configuration_from_rigid", &PyModelVisitor::getFlexiblePositionFromRigid,
-                                                              (bp::arg("self"), "rigid_position"))
-                .def("get_flexible_velocity_from_rigid", &PyModelVisitor::getFlexibleVelocityFromRigid,
-                                                         (bp::arg("self"), "rigid_velocity"))
-                .def("get_rigid_configuration_from_flexible", &PyModelVisitor::getRigidPositionFromFlexible,
-                                                              (bp::arg("self"), "flexible_position"))
-                .def("get_rigid_velocity_from_flexible", &PyModelVisitor::getRigidVelocityFromFlexible,
-                                                         (bp::arg("self"), "flexible_velocity"))
-
-                // FIXME: Disable automatic typing because typename returned by 'py_type_str' is missing module
-                // prefix, which makes it impossible to distinguish 'pinocchio.Model' from 'jiminy.Model' classes.
-                .def_readonly("pinocchio_model_th", &Model::pinocchioModelOrig_, "fget( (Model)self) -> pinocchio.Model")
-                .def_readonly("pinocchio_model", &Model::pinocchioModel_, "fget( (Model)self) -> pinocchio.Model")
-                .DEF_READONLY("collision_model_th", &Model::collisionModelOrig_)
-                .DEF_READONLY("collision_model", &Model::collisionModel_)
-                .DEF_READONLY("visual_model_th", &Model::visualModelOrig_)
-                .DEF_READONLY("visual_model", &Model::visualModel_)
-                .DEF_READONLY("visual_data", &Model::visualData_)
-                .DEF_READONLY("pinocchio_data_th", &Model::pinocchioDataOrig_)
-                .DEF_READONLY("pinocchio_data", &Model::pinocchioData_)
-                .DEF_READONLY("collision_data", &Model::collisionData_)
-
-                .DEF_READONLY("contact_forces", &Model::contactForces_)
-
-                .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
-                                              &Model::getIsInitialized,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("mesh_package_dirs",
-                                              &Model::getMeshPackageDirs,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("urdf_path",
-                                              &Model::getUrdfPath,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("has_freeflyer",
-                                              &Model::getHasFreeflyer,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET("is_flexible", &PyModelVisitor::isFlexibleModelEnabled)
-                .ADD_PROPERTY_GET_WITH_POLICY("nq",
-                                              &Model::nq,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("nv",
-                                              &Model::nv,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("nx",
-                                              &Model::nx,
-                                              bp::return_value_policy<bp::return_by_value>())
-
-                .ADD_PROPERTY_GET_WITH_POLICY("collision_body_names",
-                                              &Model::getCollisionBodyNames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("collision_body_indices",
-                                              &Model::getCollisionBodyIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("collision_pair_indices",
-                                              &Model::getCollisionPairIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("contact_frame_names",
-                                              &Model::getContactFrameNames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("contact_frame_indices",
-                                              &Model::getContactFrameIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_names",
-                                              &Model::getRigidJointNames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_index",
-                                              &Model::getRigidJointIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_position_indices",
-                                              &Model::getRigidJointPositionIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_velocity_indices",
-                                              &Model::getRigidJointVelocityIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("flexible_joint_names",
-                                              &Model::getFlexibleJointNames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("flexible_joint_indices",
-                                              &Model::getFlexibleJointIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-
-                .ADD_PROPERTY_GET_WITH_POLICY("position_limit_lower",
-                                              &Model::getPositionLimitMin,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("position_limit_upper",
-                                              &Model::getPositionLimitMax,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("velocity_limit",
-                                              &Model::getVelocityLimit,
-                                              bp::return_value_policy<bp::return_by_value>())
-
-                .ADD_PROPERTY_GET_WITH_POLICY("log_position_fieldnames",
-                                              &Model::getLogPositionFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("log_velocity_fieldnames",
-                                              &Model::getLogVelocityFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("log_acceleration_fieldnames",
-                                              &Model::getLogAccelerationFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("log_f_external_fieldnames",
-                                              &Model::getLogForceExternalFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                ;
-            // clang-format on
-        }
-
         static void addCollisionBodies(
             Model & self, const bp::object & linkNamesPy, bool ignoreMeshes)
         {
@@ -323,135 +147,186 @@ namespace jiminy::python
         {
             return self.modelOptions_->dynamics.enableFlexibleModel;
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<Model,
-                       std::shared_ptr<Model>,
-                       boost::noncopyable
-                       >("Model", bp::init<>())
-                .def(PyModelVisitor());
-            // clang-format on
-        }
-    };
-
-    BOOST_PYTHON_VISITOR_EXPOSE(Model)
-
-    // ***************************** PyRobotVisitor ***********************************
-
-    struct PyRobotVisitor : public bp::def_visitor<PyRobotVisitor>
+    void exposeModel()
     {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            // clang-format off
-            cl
-                .def("initialize", &internal::model::initialize<typename PyClass::wrapped_type>,
-                                   (bp::arg("self"), "urdf_path",
-                                    bp::arg("has_freeflyer") = false,
-                                    bp::arg("mesh_package_dirs") = bp::list(),
-                                    bp::arg("load_visual_meshes") = false))
-                .def("initialize", &internal::model::initializeFromModels<typename PyClass::wrapped_type>,
-                                   (bp::arg("self"), "pinocchio_model",
-                                    bp::arg("collision_model") = bp::object(),
-                                    bp::arg("visual_model") = bp::object()))
+        bp::class_<Model, std::shared_ptr<Model>, boost::noncopyable>("Model", bp::init<>())
+            .def("initialize",
+                 &initialize<Model>,
+                 (bp::arg("self"),
+                  "urdf_path",
+                  bp::arg("has_freeflyer") = false,
+                  bp::arg("mesh_package_dirs") = bp::list(),
+                  bp::arg("load_visual_meshes") = false))
+            .def("initialize",
+                 &initializeFromModels<Model>,
+                 (bp::arg("self"),
+                  "pinocchio_model",
+                  bp::arg("collision_model") = bp::object(),
+                  bp::arg("visual_model") = bp::object()))
 
-                .ADD_PROPERTY_GET_WITH_POLICY("is_locked",
-                                              &Robot::getIsLocked,
-                                              bp::return_value_policy<bp::return_by_value>())
+            .def("reset",
+                 makeFunction(ConvertGeneratorFromPythonAndInvoke(&Model::reset),
+                              bp::default_call_policies(),
+                              (bp::arg("self"), "generator")))
 
-                .ADD_PROPERTY_GET_WITH_POLICY("name",
-                                              &Robot::getName,
-                                              bp::return_value_policy<bp::return_by_value>())
+            .def("add_frame",
+                 static_cast<void (Model::*)(
+                     const std::string &, const std::string &, const pinocchio::SE3 &)>(
+                     &Model::addFrame),
+                 (bp::arg("self"), "frame_name", "parent_body_name", "frame_placement"))
+            .def("remove_frame", &Model::removeFrame, (bp::arg("self"), "frame_name"))
+            .def("add_collision_bodies",
+                 &internal::model::addCollisionBodies,
+                 (bp::arg("self"),
+                  bp::arg("body_names") = bp::list(),
+                  bp::arg("ignore_meshes") = false))
+            .def("remove_collision_bodies",
+                 &internal::model::removeCollisionBodies,
+                 (bp::arg("self"), "body_names"))
+            .def("add_contact_points",
+                 &internal::model::addContactPoints,
+                 (bp::arg("self"), bp::arg("frame_names") = bp::list()))
+            .def("remove_contact_points",
+                 &internal::model::removeContactPoints,
+                 (bp::arg("self"), "frame_names"))
 
-                .def("dump_options", &Robot::dumpOptions,
-                                     (bp::arg("self"), "json_filename"))
-                .def("load_options", &Robot::loadOptions,
-                                     (bp::arg("self"), "json_filename"))
+            .def("add_constraint",
+                 static_cast<void (Model::*)(const std::string &,
+                                             const std::shared_ptr<AbstractConstraintBase> &)>(
+                     &Model::addConstraint),
+                 (bp::arg("self"), "name", "constraint"))
+            .def("remove_constraint",
+                 static_cast<void (Model::*)(const std::string &)>(&Model::removeConstraint),
+                 (bp::arg("self"), "name"))
+            .def("get_constraint",
+                 static_cast<std::shared_ptr<AbstractConstraintBase> (Model::*)(
+                     const std::string &)>(&Model::getConstraint),
+                 (bp::arg("self"), "constraint_name"))
+            .def("exist_constraint", &Model::existConstraint, (bp::arg("self"), "constraint_name"))
+            .ADD_PROPERTY_GET("has_constraints", &Model::hasConstraints)
+            .ADD_PROPERTY_GET_WITH_POLICY("constraints",
+                                          &Model::getConstraints,
+                                          bp::return_value_policy<result_converter<false>>())
+            .def("get_constraints_jacobian_and_drift",
+                 &internal::model::getConstraintsJacobianAndDrift)
+            .def("compute_constraints", &Model::computeConstraints, (bp::arg("self"), "q", "v"))
 
-                .def("attach_motor", &Robot::attachMotor,
-                                     (bp::arg("self"), "motor"))
-                .def("get_motor",
-                     static_cast<
-                         std::shared_ptr<AbstractMotorBase> (Robot::*)(const std::string &)
-                     >(&Robot::getMotor),
-                     (bp::arg("self"), "motor_name"))
-                .def("detach_motor", &Robot::detachMotor,
-                                     (bp::arg("self"), "joint_name"))
-                .def("detach_motors", &PyRobotVisitor::detachMotors,
-                                      (bp::arg("self"),
-                                       bp::arg("joints_names") = bp::list()))
-                .def("attach_sensor", &Robot::attachSensor,
-                                      (bp::arg("self"), "sensor"))
-                .def("detach_sensor", &Robot::detachSensor,
-                                      (bp::arg("self"), "sensor_type", "sensor_name"))
-                .def("detach_sensors", &Robot::detachSensors,
-                                       (bp::arg("self"),
-                                        bp::arg("sensor_type") = std::string()))
-                .def("get_sensor",
-                     static_cast<
-                         std::shared_ptr<AbstractSensorBase> (Robot::*)(const std::string &, const std::string &)
-                     >(&Robot::getSensor),
-                     (bp::arg("self"), "sensor_type", "sensor_name"))
+            .def("get_flexible_configuration_from_rigid",
+                 &internal::model::getFlexiblePositionFromRigid,
+                 (bp::arg("self"), "rigid_position"))
+            .def("get_flexible_velocity_from_rigid",
+                 &internal::model::getFlexibleVelocityFromRigid,
+                 (bp::arg("self"), "rigid_velocity"))
+            .def("get_rigid_configuration_from_flexible",
+                 &internal::model::getRigidPositionFromFlexible,
+                 (bp::arg("self"), "flexible_position"))
+            .def("get_rigid_velocity_from_flexible",
+                 &internal::model::getRigidVelocityFromFlexible,
+                 (bp::arg("self"), "flexible_velocity"))
 
-                .ADD_PROPERTY_GET_SET("controller",
-                                      static_cast<
-                                          std::shared_ptr<AbstractController> (Robot::*)()
-                                      >(&Robot::getController),
-                                      &Robot::setController)
+            // FIXME: Disable automatic typing because typename returned by 'py_type_str' is
+            // missing module prefix, which makes it impossible to distinguish 'pinocchio.Model'
+            // from 'jiminy.Model' classes.
+            .def_readonly("pinocchio_model_th",
+                          &Model::pinocchioModelOrig_,
+                          "fget( (Model)self) -> pinocchio.Model")
+            .def_readonly("pinocchio_model",
+                          &Model::pinocchioModel_,
+                          "fget( (Model)self) -> pinocchio.Model")
+            .DEF_READONLY("collision_model_th", &Model::collisionModelOrig_)
+            .DEF_READONLY("collision_model", &Model::collisionModel_)
+            .DEF_READONLY("visual_model_th", &Model::visualModelOrig_)
+            .DEF_READONLY("visual_model", &Model::visualModel_)
+            .DEF_READONLY("visual_data", &Model::visualData_)
+            .DEF_READONLY("pinocchio_data_th", &Model::pinocchioDataOrig_)
+            .DEF_READONLY("pinocchio_data", &Model::pinocchioData_)
+            .DEF_READONLY("collision_data", &Model::collisionData_)
 
-                .def("compute_sensor_measurements", &PyRobotVisitor::computeSensorMeasurements,
-                                                    (bp::arg("self"), "t", "q", "v", "a", "u_motor", "f_external"))
-                .ADD_PROPERTY_GET("sensor_measurements", &PyRobotVisitor::getSensorMeasurements)
+            .DEF_READONLY("contact_forces", &Model::contactForces_)
 
-                .def("set_options", &PyRobotVisitor::setOptions,
-                                    (bp::arg("self"), "robot_options"))
-                .def("get_options", &Robot::getOptions)
-                .def("set_model_options", &PyRobotVisitor::setModelOptions,
-                                          (bp::arg("self"), "model_options"))
-                .def("get_model_options", &Robot::getModelOptions)
-                .def("set_motors_options", &PyRobotVisitor::setMotorsOptions,
-                                           (bp::arg("self"), "motors_options"))
-                .def("get_motors_options", &Robot::getMotorsOptions)
-                .def("set_sensors_options", &PyRobotVisitor::setSensorsOptions,
-                                            (bp::arg("self"), "sensors_options"))
-                .def("get_sensors_options", &Robot::getSensorsOptions)
-                .def("set_controller_options", &PyRobotVisitor::setControllerOptions,
-                                              (bp::arg("self"), "controller_options"))
-                .def("get_controller_options", &Robot::getControllerOptions)
-                .def("set_telemetry_options", &PyRobotVisitor::setTelemetryOptions,
-                                              (bp::arg("self"), "telemetry_options"))
-                .def("get_telemetry_options", &Robot::getTelemetryOptions)
+            .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
+                                          &Model::getIsInitialized,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("mesh_package_dirs",
+                                          &Model::getMeshPackageDirs,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "urdf_path", &Model::getUrdfPath, bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("has_freeflyer",
+                                          &Model::getHasFreeflyer,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET("is_flexible", &internal::model::isFlexibleModelEnabled)
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "nq", &Model::nq, bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "nv", &Model::nv, bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "nx", &Model::nx, bp::return_value_policy<bp::return_by_value>())
 
-                .ADD_PROPERTY_GET("nmotors", &Robot::nmotors)
-                .ADD_PROPERTY_GET_WITH_POLICY("motor_names",
-                                              &Robot::getMotorNames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("motor_position_indices",
-                                              &Robot::getMotorsPositionIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("motor_velocity_indices",
-                                              &Robot::getMotorVelocityIndices,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET("sensor_names", &PyRobotVisitor::getSensorNames)
+            .ADD_PROPERTY_GET_WITH_POLICY("collision_body_names",
+                                          &Model::getCollisionBodyNames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("collision_body_indices",
+                                          &Model::getCollisionBodyIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("collision_pair_indices",
+                                          &Model::getCollisionPairIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("contact_frame_names",
+                                          &Model::getContactFrameNames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("contact_frame_indices",
+                                          &Model::getContactFrameIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_names",
+                                          &Model::getRigidJointNames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_index",
+                                          &Model::getRigidJointIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_position_indices",
+                                          &Model::getRigidJointPositionIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("rigid_joint_velocity_indices",
+                                          &Model::getRigidJointVelocityIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("flexible_joint_names",
+                                          &Model::getFlexibleJointNames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("flexible_joint_indices",
+                                          &Model::getFlexibleJointIndices,
+                                          bp::return_value_policy<result_converter<true>>())
 
-                .ADD_PROPERTY_GET_WITH_POLICY("command_limit",
-                                              &Robot::getCommandLimit,
-                                              bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("position_limit_lower",
+                                          &Model::getPositionLimitMin,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("position_limit_upper",
+                                          &Model::getPositionLimitMax,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("velocity_limit",
+                                          &Model::getVelocityLimit,
+                                          bp::return_value_policy<bp::return_by_value>())
 
-                .ADD_PROPERTY_GET_WITH_POLICY("log_command_fieldnames",
-                                              &Robot::getLogCommandFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                .ADD_PROPERTY_GET_WITH_POLICY("log_motor_effort_fieldnames",
-                                              &Robot::getLogMotorEffortFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
-                ;
-            // clang-format on
-        }
+            .ADD_PROPERTY_GET_WITH_POLICY("log_position_fieldnames",
+                                          &Model::getLogPositionFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("log_velocity_fieldnames",
+                                          &Model::getLogVelocityFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("log_acceleration_fieldnames",
+                                          &Model::getLogAccelerationFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("log_f_external_fieldnames",
+                                          &Model::getLogForceExternalFieldnames,
+                                          bp::return_value_policy<result_converter<true>>());
+    }
 
+    // ***************************************** Robot ***************************************** //
+
+    namespace internal::robot
+    {
         static void detachMotors(Robot & self, const bp::object & motorNamesPy)
         {
             auto motorNames = convertFromPython<std::vector<std::string>>(motorNamesPy);
@@ -527,18 +402,110 @@ namespace jiminy::python
             convertFromPython(configPy, config);
             return self.setTelemetryOptions(config);
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<Robot, bp::bases<Model>,
-                       std::shared_ptr<Robot>,
-                       boost::noncopyable
-                       >("Robot", bp::init<const std::string &>(bp::arg("name") = ""))
-                .def(PyRobotVisitor());
-            // clang-format on
-        }
-    };
+    void exposeRobot()
+    {
+        bp::class_<Robot, bp::bases<Model>, std::shared_ptr<Robot>, boost::noncopyable>(
+            "Robot", bp::init<const std::string &>(bp::arg("name") = ""))
+            .def("initialize",
+                 &initialize<Robot>,
+                 (bp::arg("self"),
+                  "urdf_path",
+                  bp::arg("has_freeflyer") = false,
+                  bp::arg("mesh_package_dirs") = bp::list(),
+                  bp::arg("load_visual_meshes") = false))
+            .def("initialize",
+                 &initializeFromModels<Robot>,
+                 (bp::arg("self"),
+                  "pinocchio_model",
+                  bp::arg("collision_model") = bp::object(),
+                  bp::arg("visual_model") = bp::object()))
 
-    BOOST_PYTHON_VISITOR_EXPOSE(Robot)
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "is_locked", &Robot::getIsLocked, bp::return_value_policy<bp::return_by_value>())
+
+            .ADD_PROPERTY_GET_WITH_POLICY(
+                "name", &Robot::getName, bp::return_value_policy<bp::return_by_value>())
+
+            .def("dump_options", &Robot::dumpOptions, (bp::arg("self"), "json_filename"))
+            .def("load_options", &Robot::loadOptions, (bp::arg("self"), "json_filename"))
+
+            .def("attach_motor", &Robot::attachMotor, (bp::arg("self"), "motor"))
+            .def("get_motor",
+                 static_cast<std::shared_ptr<AbstractMotorBase> (Robot::*)(const std::string &)>(
+                     &Robot::getMotor),
+                 (bp::arg("self"), "motor_name"))
+            .def("detach_motor", &Robot::detachMotor, (bp::arg("self"), "joint_name"))
+            .def("detach_motors",
+                 &internal::robot::detachMotors,
+                 (bp::arg("self"), bp::arg("joints_names") = bp::list()))
+            .def("attach_sensor", &Robot::attachSensor, (bp::arg("self"), "sensor"))
+            .def("detach_sensor",
+                 &Robot::detachSensor,
+                 (bp::arg("self"), "sensor_type", "sensor_name"))
+            .def("detach_sensors",
+                 &Robot::detachSensors,
+                 (bp::arg("self"), bp::arg("sensor_type") = std::string()))
+            .def("get_sensor",
+                 static_cast<std::shared_ptr<AbstractSensorBase> (Robot::*)(
+                     const std::string &, const std::string &)>(&Robot::getSensor),
+                 (bp::arg("self"), "sensor_type", "sensor_name"))
+
+            .ADD_PROPERTY_GET_SET("controller",
+                                  static_cast<std::shared_ptr<AbstractController> (Robot::*)()>(
+                                      &Robot::getController),
+                                  &Robot::setController)
+
+            .def("compute_sensor_measurements",
+                 &internal::robot::computeSensorMeasurements,
+                 (bp::arg("self"), "t", "q", "v", "a", "u_motor", "f_external"))
+            .ADD_PROPERTY_GET("sensor_measurements", &internal::robot::getSensorMeasurements)
+
+            .def("set_options", &internal::robot::setOptions, (bp::arg("self"), "robot_options"))
+            .def("get_options", &Robot::getOptions)
+            .def("set_model_options",
+                 &internal::robot::setModelOptions,
+                 (bp::arg("self"), "model_options"))
+            .def("get_model_options", &Robot::getModelOptions)
+            .def("set_motors_options",
+                 &internal::robot::setMotorsOptions,
+                 (bp::arg("self"), "motors_options"))
+            .def("get_motors_options", &Robot::getMotorsOptions)
+            .def("set_sensors_options",
+                 &internal::robot::setSensorsOptions,
+                 (bp::arg("self"), "sensors_options"))
+            .def("get_sensors_options", &Robot::getSensorsOptions)
+            .def("set_controller_options",
+                 &internal::robot::setControllerOptions,
+                 (bp::arg("self"), "controller_options"))
+            .def("get_controller_options", &Robot::getControllerOptions)
+            .def("set_telemetry_options",
+                 &internal::robot::setTelemetryOptions,
+                 (bp::arg("self"), "telemetry_options"))
+            .def("get_telemetry_options", &Robot::getTelemetryOptions)
+
+            .ADD_PROPERTY_GET("nmotors", &Robot::nmotors)
+            .ADD_PROPERTY_GET_WITH_POLICY("motor_names",
+                                          &Robot::getMotorNames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("motor_position_indices",
+                                          &Robot::getMotorsPositionIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("motor_velocity_indices",
+                                          &Robot::getMotorVelocityIndices,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET("sensor_names", &internal::robot::getSensorNames)
+
+            .ADD_PROPERTY_GET_WITH_POLICY("command_limit",
+                                          &Robot::getCommandLimit,
+                                          bp::return_value_policy<bp::return_by_value>())
+
+            .ADD_PROPERTY_GET_WITH_POLICY("log_command_fieldnames",
+                                          &Robot::getLogCommandFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("log_motor_effort_fieldnames",
+                                          &Robot::getLogMotorEffortFieldnames,
+                                          bp::return_value_policy<result_converter<true>>());
+    }
 }

--- a/python/jiminy_pywrap/src/robot.cc
+++ b/python/jiminy_pywrap/src/robot.cc
@@ -338,18 +338,6 @@ namespace jiminy::python
             return std::make_shared<SensorMeasurementTree>(self.getSensorMeasurements());
         }
 
-        static void computeSensorMeasurements(Robot & self,
-                                              double t,
-                                              const Eigen::VectorXd & q,
-                                              const Eigen::VectorXd & v,
-                                              const Eigen::VectorXd & a,
-                                              const Eigen::VectorXd & uMotor,
-                                              const bp::list & fExternalPy)
-        {
-            ForceVector fExternal = bp::extract<ForceVector>(fExternalPy);
-            self.computeSensorMeasurements(t, q, v, a, uMotor, fExternal);
-        }
-
         static bp::dict getSensorNames(Robot & self)
         {
             bp::dict sensorsNamesPy;
@@ -458,7 +446,7 @@ namespace jiminy::python
                                   &Robot::setController)
 
             .def("compute_sensor_measurements",
-                 &internal::robot::computeSensorMeasurements,
+                 &Robot::computeSensorMeasurements,
                  (bp::arg("self"), "t", "q", "v", "a", "u_motor", "f_external"))
             .ADD_PROPERTY_GET("sensor_measurements", &internal::robot::getSensorMeasurements)
 

--- a/python/jiminy_pywrap/src/sensors.cc
+++ b/python/jiminy_pywrap/src/sensors.cc
@@ -14,64 +14,11 @@ namespace jiminy::python
 
     // ********************************* SensorMeasurementTree ********************************* //
 
-    struct PySensorMeasurementTreeVisitor : public bp::def_visitor<PySensorMeasurementTreeVisitor>
+    namespace internal::sensor_measurement_tree
     {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
+        static bp::ssize_t len(SensorMeasurementTree & self)
         {
-            // clang-format off
-            cl
-                /* with_custodian_and_ward_postcall is used to tie the lifetime of the Python
-                   object with the one of the C++ reference, so that the Python object does not
-                   get deleted while the C++ object is not. */
-                .def("__init__", &PySensorMeasurementTreeVisitor::factoryWrapper,
-                                 bp::with_custodian_and_ward_postcall<1, 2>(),
-                                 (bp::arg("self"), "sensor_measurements"))
-                .def("__len__", &PySensorMeasurementTreeVisitor::len,
-                                (bp::arg("self")))
-                .def("__getitem__", &PySensorMeasurementTreeVisitor::getItem,
-                                    bp::return_value_policy<result_converter<false>>(),
-                                    (bp::arg("self"), "sensor_info"))
-                .def("__getitem__", &PySensorMeasurementTreeVisitor::getItemSplit,
-                                    bp::return_value_policy<result_converter<false>>(),
-                                    (bp::arg("self"), "sensor_type", "sensor_name"))
-                .def("__getitem__", &PySensorMeasurementTreeVisitor::getSub,
-                                    bp::return_value_policy<result_converter<false>>(),
-                                    (bp::arg("self"), "sensor_type"))
-                /* Using '__iter__' is discouraged because it has very poor efficiency due to
-                   the overhead of translating 'StopIteration' exception when reaching the end. */
-                .def("__iter__", bp::range<bp::return_value_policy<result_converter<false>>>(
-                                 static_cast<
-                                     SensorMeasurementTree::iterator (SensorMeasurementTree::*)(void)
-                                 >(&SensorMeasurementTree::begin),
-                                 static_cast<
-                                     SensorMeasurementTree::iterator (SensorMeasurementTree::*)(void)
-                                 >(&SensorMeasurementTree::end)))
-                .def("__contains__", &PySensorMeasurementTreeVisitor::contains,
-                                     (bp::arg("self"), "key"))
-                .def("__repr__", &PySensorMeasurementTreeVisitor::repr)
-                .def("keys", &PySensorMeasurementTreeVisitor::keys,
-                             (bp::arg("self")))
-                .def("keys", &PySensorMeasurementTreeVisitor::keysSensorType,
-                             (bp::arg("self"), "sensor_type"))
-                .def("values", &PySensorMeasurementTreeVisitor::values,
-                               (bp::arg("self")))
-                .def("items", &PySensorMeasurementTreeVisitor::items,
-                              (bp::arg("self")))
-                ;
-            // clang-format on
-        }
-
-        static bp::ssize_t len(SensorMeasurementTree & self) { return self.size(); }
-
-        static const Eigen::Ref<const Eigen::VectorXd> & getItem(SensorMeasurementTree & self,
-                                                                 const bp::tuple & sensorInfo)
-        {
-            const std::string sensorType = bp::extract<std::string>(sensorInfo[0]);
-            const std::string sensorName = bp::extract<std::string>(sensorInfo[1]);
-            return PySensorMeasurementTreeVisitor::getItemSplit(self, sensorType, sensorName);
+            return self.size();
         }
 
         static const Eigen::Ref<const Eigen::VectorXd> & getItemSplit(
@@ -97,6 +44,14 @@ namespace jiminy::python
                 PyErr_SetString(PyExc_KeyError, errorMsg.str().c_str());
                 throw bp::error_already_set();
             }
+        }
+
+        static const Eigen::Ref<const Eigen::VectorXd> & getItem(SensorMeasurementTree & self,
+                                                                 const bp::tuple & sensorInfo)
+        {
+            const std::string sensorType = bp::extract<std::string>(sensorInfo[0]);
+            const std::string sensorName = bp::extract<std::string>(sensorInfo[1]);
+            return internal::sensor_measurement_tree::getItemSplit(self, sensorType, sensorName);
         }
 
         static const Eigen::MatrixXd & getSub(SensorMeasurementTree & self,
@@ -203,69 +158,60 @@ namespace jiminy::python
 
         static void factoryWrapper(bp::object & self, bp::dict & sensorDataPy)
         {
-            auto constructor = bp::make_constructor(&PySensorMeasurementTreeVisitor::factory);
+            auto constructor = bp::make_constructor(&internal::sensor_measurement_tree::factory);
             constructor(self, sensorDataPy);
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<SensorMeasurementTree,
-                       std::shared_ptr<SensorMeasurementTree>,
-                       boost::noncopyable>("SensorMeasurementTree", bp::no_init)
-                .def(PySensorMeasurementTreeVisitor());
-            // clang-format on
-        }
-    };
-
-    BOOST_PYTHON_VISITOR_EXPOSE(SensorMeasurementTree)
-
-    // ************************* PyAbstractSensorVisitor ******************************
-
-    struct PyAbstractSensorVisitor : public bp::def_visitor<PyAbstractSensorVisitor>
+    void exposeSensorMeasurementTree()
     {
-    public:
-        /// \brief Expose C++ API through the visitor.
-        template<class PyClass>
-        void visit(PyClass & cl) const
-        {
-            // clang-format off
-            cl
-                .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
-                                              &AbstractSensorBase::getIsInitialized,
-                                              bp::return_value_policy<bp::return_by_value>())
+        bp::class_<SensorMeasurementTree,
+                   std::shared_ptr<SensorMeasurementTree>,
+                   boost::noncopyable>("SensorMeasurementTree", bp::no_init)
+            /* with_custodian_and_ward_postcall is used to tie the lifetime of the Python
+               object with the one of the C++ reference, so that the Python object does not
+               get deleted while the C++ object is not. */
+            .def("__init__",
+                 &internal::sensor_measurement_tree::factoryWrapper,
+                 bp::with_custodian_and_ward_postcall<1, 2>(),
+                 (bp::arg("self"), "sensor_measurements"))
+            .def("__len__", &internal::sensor_measurement_tree::len, (bp::arg("self")))
+            .def("__getitem__",
+                 &internal::sensor_measurement_tree::getItem,
+                 bp::return_value_policy<result_converter<false>>(),
+                 (bp::arg("self"), "sensor_info"))
+            .def("__getitem__",
+                 &internal::sensor_measurement_tree::getItemSplit,
+                 bp::return_value_policy<result_converter<false>>(),
+                 (bp::arg("self"), "sensor_type", "sensor_name"))
+            .def("__getitem__",
+                 &internal::sensor_measurement_tree::getSub,
+                 bp::return_value_policy<result_converter<false>>(),
+                 (bp::arg("self"), "sensor_type"))
+            /* Using '__iter__' is discouraged because it has very poor efficiency due to
+               the overhead of translating 'StopIteration' exception when reaching the end. */
+            .def("__iter__",
+                 bp::range<bp::return_value_policy<result_converter<false>>>(
+                     static_cast<SensorMeasurementTree::iterator (SensorMeasurementTree::*)(void)>(
+                         &SensorMeasurementTree::begin),
+                     static_cast<SensorMeasurementTree::iterator (SensorMeasurementTree::*)(void)>(
+                         &SensorMeasurementTree::end)))
+            .def("__contains__",
+                 &internal::sensor_measurement_tree::contains,
+                 (bp::arg("self"), "key"))
+            .def("__repr__", &internal::sensor_measurement_tree::repr)
+            .def("keys", &internal::sensor_measurement_tree::keys, (bp::arg("self")))
+            .def("keys",
+                 &internal::sensor_measurement_tree::keysSensorType,
+                 (bp::arg("self"), "sensor_type"))
+            .def("values", &internal::sensor_measurement_tree::values, (bp::arg("self")))
+            .def("items", &internal::sensor_measurement_tree::items, (bp::arg("self")));
+    }
 
-                .ADD_PROPERTY_GET_WITH_POLICY("type",
-                                              &AbstractSensorBase::getType,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("fieldnames",
-                                              &AbstractSensorBase::getFieldnames,
-                                              bp::return_value_policy<result_converter<true>>())
+    // ************************************* AbstractSensor ************************************ //
 
-                .ADD_PROPERTY_GET_WITH_POLICY("name",
-                                              &AbstractSensorBase::getName,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_WITH_POLICY("index",
-                                              &AbstractSensorBase::getIndex,
-                                              bp::return_value_policy<bp::return_by_value>())
-                .ADD_PROPERTY_GET_SET_WITH_POLICY("data",
-                                                  static_cast<
-                                                      Eigen::Ref<const Eigen::VectorXd> (AbstractSensorBase::*)(void) const
-                                                  >(&AbstractSensorBase::get),
-                                                  bp::return_value_policy<result_converter<false>>(),
-                                                  static_cast<
-                                                      void (AbstractSensorBase::*)(const Eigen::MatrixBase<Eigen::VectorXd> &)
-                                                  >(&AbstractSensorBase::set))
-
-                .def("set_options", &PyAbstractSensorVisitor::setOptions)
-                .def("get_options", &AbstractSensorBase::getOptions)
-
-                .def("__repr__", &PyAbstractSensorVisitor::repr)
-                ;
-            // clang-format on
-        }
-
-    public:
+    namespace internal::abstract_sensor
+    {
         static std::string repr(AbstractSensorBase & self)
         {
             std::stringstream s;
@@ -295,21 +241,44 @@ namespace jiminy::python
             convertFromPython(configPy, config);
             return self.setOptions(config);
         }
+    }
 
-        static void expose()
-        {
-            // clang-format off
-            bp::class_<AbstractSensorBase,
-                       std::shared_ptr<AbstractSensorBase>,
-                       boost::noncopyable>("AbstractSensor", bp::no_init)
-                .def(PyAbstractSensorVisitor());
-            // clang-format on
-        }
-    };
+    void exposeAbstractSensor()
+    {
+        bp::class_<AbstractSensorBase, std::shared_ptr<AbstractSensorBase>, boost::noncopyable>(
+            "AbstractSensor", bp::no_init)
+            .ADD_PROPERTY_GET_WITH_POLICY("is_initialized",
+                                          &AbstractSensorBase::getIsInitialized,
+                                          bp::return_value_policy<bp::return_by_value>())
 
-    BOOST_PYTHON_VISITOR_EXPOSE(AbstractSensor)
+            .ADD_PROPERTY_GET_WITH_POLICY("type",
+                                          &AbstractSensorBase::getType,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("fieldnames",
+                                          &AbstractSensorBase::getFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
 
-    // ************************** PyBasicSensorsVisitor ******************************
+            .ADD_PROPERTY_GET_WITH_POLICY("name",
+                                          &AbstractSensorBase::getName,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_WITH_POLICY("index",
+                                          &AbstractSensorBase::getIndex,
+                                          bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET_SET_WITH_POLICY(
+                "data",
+                static_cast<Eigen::Ref<const Eigen::VectorXd> (AbstractSensorBase::*)(void) const>(
+                    &AbstractSensorBase::get),
+                bp::return_value_policy<result_converter<false>>(),
+                static_cast<void (AbstractSensorBase::*)(
+                    const Eigen::MatrixBase<Eigen::VectorXd> &)>(&AbstractSensorBase::set))
+
+            .def("set_options", &internal::abstract_sensor::setOptions)
+            .def("get_options", &AbstractSensorBase::getOptions)
+
+            .def("__repr__", &internal::abstract_sensor::repr);
+    }
+
+    // ************************************** BasicSensors ************************************* //
 
     struct PyBasicSensorsVisitor : public bp::def_visitor<PyBasicSensorsVisitor>
     {
@@ -414,44 +383,45 @@ namespace jiminy::python
 
         static void expose()
         {
-            // clang-format off
-            bp::class_<ImuSensor, bp::bases<AbstractSensorBase>,
+            bp::class_<ImuSensor,
+                       bp::bases<AbstractSensorBase>,
                        std::shared_ptr<ImuSensor>,
-                       boost::noncopyable>("ImuSensor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "frame_name")))
+                       boost::noncopyable>(
+                "ImuSensor", bp::init<const std::string &>((bp::arg("self"), "frame_name")))
                 .def(PyBasicSensorsVisitor());
 
-            bp::class_<ContactSensor, bp::bases<AbstractSensorBase>,
+            bp::class_<ContactSensor,
+                       bp::bases<AbstractSensorBase>,
                        std::shared_ptr<ContactSensor>,
-                       boost::noncopyable>("ContactSensor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "frame_name")))
+                       boost::noncopyable>(
+                "ContactSensor", bp::init<const std::string &>((bp::arg("self"), "frame_name")))
                 .def(PyBasicSensorsVisitor());
 
-            bp::class_<ForceSensor, bp::bases<AbstractSensorBase>,
+            bp::class_<ForceSensor,
+                       bp::bases<AbstractSensorBase>,
                        std::shared_ptr<ForceSensor>,
-                       boost::noncopyable>("ForceSensor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "frame_name")))
+                       boost::noncopyable>(
+                "ForceSensor", bp::init<const std::string &>((bp::arg("self"), "frame_name")))
                 .def(PyBasicSensorsVisitor());
 
-            bp::class_<EncoderSensor, bp::bases<AbstractSensorBase>,
+            bp::class_<EncoderSensor,
+                       bp::bases<AbstractSensorBase>,
                        std::shared_ptr<EncoderSensor>,
-                       boost::noncopyable>("EncoderSensor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "joint_name")))
+                       boost::noncopyable>(
+                "EncoderSensor", bp::init<const std::string &>((bp::arg("self"), "joint_name")))
                 .def(PyBasicSensorsVisitor());
 
-            bp::class_<EffortSensor, bp::bases<AbstractSensorBase>,
+            bp::class_<EffortSensor,
+                       bp::bases<AbstractSensorBase>,
                        std::shared_ptr<EffortSensor>,
-                       boost::noncopyable>("EffortSensor",
-                       bp::init<const std::string &>(
-                       (bp::arg("self"), "joint_name")))
+                       boost::noncopyable>(
+                "EffortSensor", bp::init<const std::string &>((bp::arg("self"), "joint_name")))
                 .def(PyBasicSensorsVisitor());
-            // clang-format on
         }
     };
 
-    BOOST_PYTHON_VISITOR_EXPOSE(BasicSensors)
+    void exposeBasicSensors()
+    {
+        PyBasicSensorsVisitor::expose();
+    }
 }


### PR DESCRIPTION
* [core] Make visual and collision models optional.
* [core] Throw exception when trying to alter hardware or controller internals during simulation.
* [core] Mark src-local functions as static.
* [core] Add some missing bad control flow checks.
* [core/python] 'Model' can now be instantiated from Python.
* [core/python] Fix partially broken 'FunctionalController' bindings.
* [core/python] Avoid visitor pattern when irrelevant.