### PR TITLE
[core] Add Perlin ground profile generators.

### DIFF
--- a/core/include/jiminy/core/fwd.h
+++ b/core/include/jiminy/core/fwd.h
@@ -189,6 +189,11 @@ namespace jiminy
         using std::logic_error::logic_error::what;
     };
 
+    template<typename ResultType,
+             ResultType min_ = std::numeric_limits<ResultType>::min(),
+             ResultType max_ = std::numeric_limits<ResultType>::max()>
+    class uniform_random_bit_generator_ref;
+
     // Ground profile functors
     using HeightmapFunction = std::function<void(const Eigen::Vector2d & /* xy */,
                                                  double & /* height */,

--- a/core/include/jiminy/core/fwd.h
+++ b/core/include/jiminy/core/fwd.h
@@ -194,7 +194,8 @@ namespace jiminy
              ResultType max_ = std::numeric_limits<ResultType>::max()>
     class uniform_random_bit_generator_ref;
 
-    // Ground profile functors
+    // Ground profile functors.
+    // FIXME: use `std::move_only_function` instead of `std::function` when moving to C++23
     using HeightmapFunction = std::function<void(const Eigen::Vector2d & /* xy */,
                                                  double & /* height */,
                                                  Eigen::Ref<Eigen::Vector3d> /* normal */)>;

--- a/core/include/jiminy/core/robot/model.h
+++ b/core/include/jiminy/core/robot/model.h
@@ -1,6 +1,8 @@
 #ifndef JIMINY_MODEL_H
 #define JIMINY_MODEL_H
 
+#include <optional>
+
 #include "pinocchio/spatial/fwd.hpp"         // `pinocchio::SE3`
 #include "pinocchio/multibody/model.hpp"     // `pinocchio::Model`
 #include "pinocchio/multibody/data.hpp"      // `pinocchio::Data`

--- a/core/include/jiminy/core/robot/model.h
+++ b/core/include/jiminy/core/robot/model.h
@@ -8,7 +8,6 @@
 #include "pinocchio/multibody/frame.hpp"  // `pinocchio::FrameType` (C-style enum cannot be forward declared)
 
 #include "jiminy/core/fwd.h"
-#include "jiminy/core/utilities/random.h"  // `uniform_random_bit_generator_ref`
 
 
 namespace jiminy

--- a/core/include/jiminy/core/stepper/lie_group.h
+++ b/core/include/jiminy/core/stepper/lie_group.h
@@ -1238,7 +1238,7 @@ namespace Eigen
 
 #define StateDerivative_SHARED_ADDON                                                          \
     template<typename Derived,                                                                \
-             typename = typename std::enable_if_t<                                            \
+             typename = std::enable_if_t<                                                     \
                  is_base_of_template_v<StateDerivativeBase,                                   \
                                        typename internal::traits<Derived>::ValueType>::value, \
                  void>>                                                                       \
@@ -1268,7 +1268,7 @@ namespace Eigen
     template<                                                                                     \
         typename Derived,                                                                         \
         typename OtherDerived,                                                                    \
-        typename = typename std::enable_if_t<                                                     \
+        typename = std::enable_if_t<                                                              \
             is_base_of_template_v<StateDerivativeBase,                                            \
                                   typename internal::traits<Derived>::ValueType>::value &&        \
                 is_base_of_template_v<StateBase,                                                  \
@@ -1290,7 +1290,7 @@ namespace Eigen
     }                                                                                             \
                                                                                                   \
     template<typename Derived,                                                                    \
-             typename = typename std::enable_if_t<                                                \
+             typename = std::enable_if_t<                                                         \
                  is_base_of_template_v<StateDerivativeBase,                                       \
                                        typename internal::traits<Derived>::ValueType>::value,     \
                  void>>                                                                           \
@@ -1301,7 +1301,7 @@ namespace Eigen
     }                                                                                             \
                                                                                                   \
     template<typename Derived,                                                                    \
-             typename = typename std::enable_if_t<                                                \
+             typename = std::enable_if_t<                                                         \
                  is_base_of_template_v<StateDerivativeBase,                                       \
                                        typename internal::traits<Derived>::ValueType>::value,     \
                  void>>                                                                           \
@@ -1320,7 +1320,7 @@ namespace Eigen
     template<                                                                                     \
         typename Derived,                                                                         \
         typename OtherDerived,                                                                    \
-        typename = typename std::enable_if_t<                                                     \
+        typename = std::enable_if_t<                                                              \
             is_base_of_template_v<StateBase,                                                      \
                                   typename internal::traits<Derived>::ValueType>::value &&        \
                 is_base_of_template_v<StateDerivativeBase,                                        \

--- a/core/include/jiminy/core/utilities/geometry.h
+++ b/core/include/jiminy/core/utilities/geometry.h
@@ -46,7 +46,7 @@ namespace jiminy
     /// \param[in] stepHeight  Heigh of the steps.
     /// \param[in] stepNumber  Number of steps in the ascending or descending direction.
     /// \param[in] orientation Orientation of the staircases in the XY plane.
-    HeightmapFunction JIMINY_DLLAPI stairs(
+    HeightmapFunction JIMINY_DLLAPI periodicStairs(
         double stepWidth, double stepHeight, uint32_t stepNumber, double orientation);
 }
 

--- a/core/include/jiminy/core/utilities/geometry.h
+++ b/core/include/jiminy/core/utilities/geometry.h
@@ -48,6 +48,21 @@ namespace jiminy
     /// \param[in] orientation Orientation of the staircases in the XY plane.
     HeightmapFunction JIMINY_DLLAPI periodicStairs(
         double stepWidth, double stepHeight, uint32_t stepNumber, double orientation);
+
+    HeightmapFunction JIMINY_DLLAPI unidirectionalRandomPerlinGround(
+        double wavelength, std::size_t numOctaves, double orientation, uint32_t seed);
+
+    HeightmapFunction JIMINY_DLLAPI unidirectionalPeriodicPerlinGround(double wavelength,
+                                                                       double period,
+                                                                       std::size_t numOctaves,
+                                                                       double orientation,
+                                                                       uint32_t seed);
+
+    HeightmapFunction JIMINY_DLLAPI randomPerlinGround(
+        double wavelength, std::size_t numOctaves, uint32_t seed);
+
+    HeightmapFunction JIMINY_DLLAPI periodicPerlinGround(
+        double wavelength, double period, std::size_t numOctaves, uint32_t seed);
 }
 
 #endif  // JIMINY_GEOMETRY_H

--- a/core/include/jiminy/core/utilities/random.h
+++ b/core/include/jiminy/core/utilities/random.h
@@ -429,12 +429,17 @@ namespace jiminy
         virtual void reset(const uniform_random_bit_generator_ref<uint32_t> & g) noexcept;
 
         double operator()(const VectorN<double> & x) const;
-        // VectorN<double> grad(VectorN<double> const & x) const;
+        VectorN<double> grad(const VectorN<double> & x) const;
 
         double getWavelength() const noexcept;
 
     protected:
         virtual VectorN<double> grad(const VectorN<int32_t> & knot) const noexcept = 0;
+
+    private:
+        template<bool isGradient>
+        std::conditional_t<isGradient, VectorN<double>, double>
+        evaluate(const VectorN<double> & x) const;
 
     protected:
         const double wavelength_;
@@ -524,6 +529,7 @@ namespace jiminy
         void reset(const uniform_random_bit_generator_ref<uint32_t> & g) noexcept;
 
         double operator()(const VectorN<double> & x) const;
+        VectorN<double> grad(const VectorN<double> & x) const;
 
         double getWavelength() const noexcept;
         std::size_t getNumOctaves() const noexcept;

--- a/core/include/jiminy/core/utilities/random.h
+++ b/core/include/jiminy/core/utilities/random.h
@@ -314,7 +314,7 @@ namespace jiminy
         standardToeplitzCholeskyLower(const Eigen::MatrixBase<Derived> & coeffs, double reg = 0.0);
     }
 
-    class JIMINY_DLLAPI PeriodicTabularProcess
+    class JIMINY_TEMPLATE_DLLAPI PeriodicTabularProcess
     {
     public:
         explicit PeriodicTabularProcess(double wavelength, double period);
@@ -337,7 +337,7 @@ namespace jiminy
         Eigen::VectorXd grads_{numTimes_};
     };
 
-    class JIMINY_DLLAPI PeriodicGaussianProcess final : public PeriodicTabularProcess
+    class JIMINY_TEMPLATE_DLLAPI PeriodicGaussianProcess final : public PeriodicTabularProcess
     {
     public:
         explicit PeriodicGaussianProcess(double wavelength, double period);
@@ -385,7 +385,7 @@ namespace jiminy
     /// \see For references about the derivatives of a Gaussian Process:
     ///      http://herbsusmann.com/2020/07/06/gaussian-process-derivatives
     ///      https://arxiv.org/abs/1810.12283
-    class JIMINY_DLLAPI PeriodicFourierProcess final : public PeriodicTabularProcess
+    class JIMINY_TEMPLATE_DLLAPI PeriodicFourierProcess final : public PeriodicTabularProcess
     {
     public:
         explicit PeriodicFourierProcess(double wavelength, double period);
@@ -413,7 +413,7 @@ namespace jiminy
     uint32_t MurmurHash3(const void * key, int32_t len, uint32_t seed) noexcept;
 
     template<template<unsigned int> class DerivedPerlinNoiseOctave, unsigned int N>
-    class JIMINY_DLLAPI AbstractPerlinNoiseOctave
+    class JIMINY_TEMPLATE_DLLAPI AbstractPerlinNoiseOctave
     {
     public:
         template<typename Scalar>
@@ -441,7 +441,7 @@ namespace jiminy
     };
 
     template<unsigned int N>
-    class JIMINY_DLLAPI RandomPerlinNoiseOctave :
+    class JIMINY_TEMPLATE_DLLAPI RandomPerlinNoiseOctave :
     public AbstractPerlinNoiseOctave<RandomPerlinNoiseOctave, N>
     {
     public:
@@ -463,7 +463,7 @@ namespace jiminy
     };
 
     template<unsigned int N>
-    class JIMINY_DLLAPI PeriodicPerlinNoiseOctave :
+    class JIMINY_TEMPLATE_DLLAPI PeriodicPerlinNoiseOctave :
     public AbstractPerlinNoiseOctave<PeriodicPerlinNoiseOctave, N>
     {
     public:
@@ -518,7 +518,7 @@ namespace jiminy
     class AbstractPerlinProcess;
 
     template<template<unsigned int> class DerivedPerlinNoiseOctave, unsigned int N>
-    class JIMINY_DLLAPI AbstractPerlinProcess<DerivedPerlinNoiseOctave, N>
+    class JIMINY_TEMPLATE_DLLAPI AbstractPerlinProcess<DerivedPerlinNoiseOctave, N>
     {
     public:
         template<typename Scalar>
@@ -546,7 +546,7 @@ namespace jiminy
     };
 
     template<unsigned int N>
-    class JIMINY_DLLAPI RandomPerlinProcess :
+    class JIMINY_TEMPLATE_DLLAPI RandomPerlinProcess :
     public AbstractPerlinProcess<RandomPerlinNoiseOctave, N>
     {
     public:

--- a/core/include/jiminy/core/utilities/random.h
+++ b/core/include/jiminy/core/utilities/random.h
@@ -220,9 +220,9 @@ namespace jiminy
 
     template<typename Generator, typename Derived1, typename Derived2>
     std::enable_if_t<
-        (is_eigen_any_v<Derived1> ||
-         is_eigen_any_v<Derived2>)&&(!std::is_arithmetic_v<std::decay_t<Derived1>> ||
-                                     !std::is_arithmetic_v<std::decay_t<Derived2>>),
+        (is_eigen_any_v<Derived1> || is_eigen_any_v<Derived2>) &&
+            (!std::is_arithmetic_v<std::decay_t<Derived1>> ||
+             !std::is_arithmetic_v<std::decay_t<Derived2>>),
         Eigen::CwiseNullaryOp<
             scalar_random_op<float(const uniform_random_bit_generator_ref<uint32_t> &, float, float),
                              Generator &,
@@ -271,9 +271,9 @@ namespace jiminy
     /// optimizations enabled (level 01 is enough), probably due to inlining.
     template<typename Generator, typename Derived1, typename Derived2>
     std::enable_if_t<
-        (is_eigen_any_v<Derived1> ||
-         is_eigen_any_v<Derived2>)&&(!std::is_arithmetic_v<std::decay_t<Derived1>> ||
-                                     !std::is_arithmetic_v<std::decay_t<Derived2>>),
+        (is_eigen_any_v<Derived1> || is_eigen_any_v<Derived2>) &&
+            (!std::is_arithmetic_v<std::decay_t<Derived1>> ||
+             !std::is_arithmetic_v<std::decay_t<Derived2>>),
         Eigen::CwiseNullaryOp<
             scalar_random_op<float(const uniform_random_bit_generator_ref<uint32_t> &, float, float),
                              Generator &,
@@ -461,7 +461,8 @@ namespace jiminy
     private:
         const double period_;
 
-        std::array<uint8_t, 256> perm_{};
+        std::vector<uint32_t> hashes_ =
+            std::vector<uint32_t>(static_cast<std::size_t>(period_ / wavelength_));
     };
 
     /// \brief  Sum of Perlin noise octaves.

--- a/core/include/jiminy/core/utilities/random.h
+++ b/core/include/jiminy/core/utilities/random.h
@@ -331,7 +331,7 @@ namespace jiminy
         const double wavelength_;
         const double period_;
         const Eigen::Index numTimes_{static_cast<int>(std::ceil(period_ / (0.1 * wavelength_)))};
-        const double dt_{period_ / numTimes_};
+        const double dt_{period_ / static_cast<double>(numTimes_)};
 
         Eigen::VectorXd values_{numTimes_};
         Eigen::VectorXd grads_{numTimes_};

--- a/core/include/jiminy/core/utilities/random.hxx
+++ b/core/include/jiminy/core/utilities/random.hxx
@@ -57,9 +57,9 @@ namespace jiminy
 
     template<typename Generator, typename Derived1, typename Derived2>
     std::enable_if_t<
-        (is_eigen_any_v<Derived1> ||
-         is_eigen_any_v<Derived2>)&&(!std::is_arithmetic_v<std::decay_t<Derived1>> ||
-                                     !std::is_arithmetic_v<std::decay_t<Derived2>>),
+        (is_eigen_any_v<Derived1> || is_eigen_any_v<Derived2>) &&
+            (!std::is_arithmetic_v<std::decay_t<Derived1>> ||
+             !std::is_arithmetic_v<std::decay_t<Derived2>>),
         Eigen::CwiseNullaryOp<
             scalar_random_op<float(const uniform_random_bit_generator_ref<uint32_t> &, float, float),
                              Generator &,
@@ -103,9 +103,9 @@ namespace jiminy
 
     template<typename Generator, typename Derived1, typename Derived2>
     std::enable_if_t<
-        (is_eigen_any_v<Derived1> ||
-         is_eigen_any_v<Derived2>)&&(!std::is_arithmetic_v<std::decay_t<Derived1>> ||
-                                     !std::is_arithmetic_v<std::decay_t<Derived2>>),
+        (is_eigen_any_v<Derived1> || is_eigen_any_v<Derived2>) &&
+            (!std::is_arithmetic_v<std::decay_t<Derived1>> ||
+             !std::is_arithmetic_v<std::decay_t<Derived2>>),
         Eigen::CwiseNullaryOp<
             scalar_random_op<float(const uniform_random_bit_generator_ref<uint32_t> &, float, float),
                              Generator &,
@@ -153,7 +153,7 @@ namespace jiminy
     {
         template<typename Derived>
         MatrixX<typename Derived::Scalar>
-        standardToeplitzCholeskyLower(const Eigen::MatrixBase<Derived> & coeffs)
+        standardToeplitzCholeskyLower(const Eigen::MatrixBase<Derived> & coeffs, double reg)
         {
             using Scalar = typename Derived::Scalar;
 
@@ -165,6 +165,7 @@ namespace jiminy
                It coincides with the Schur generator for Toepliz matrices. */
             Eigen::Matrix<Scalar, 2, Eigen::Dynamic> g{2, n};
             g.rowwise() = coeffs.transpose();
+            g(0, 0) += reg;
 
             // Run progressive Schur algorithm, adapted to Toepliz matrices
             l.col(0) = g.row(0);

--- a/core/include/jiminy/core/utilities/random.hxx
+++ b/core/include/jiminy/core/utilities/random.hxx
@@ -462,6 +462,12 @@ namespace jiminy
     }
 
     template<unsigned int N>
+    double PeriodicPerlinNoiseOctave<N>::getPeriod() const noexcept
+    {
+        return period_;
+    }
+
+    template<unsigned int N>
     void PeriodicPerlinNoiseOctave<N>::reset(
         const uniform_random_bit_generator_ref<uint32_t> & g) noexcept
     {

--- a/core/include/jiminy/core/utilities/random.hxx
+++ b/core/include/jiminy/core/utilities/random.hxx
@@ -418,7 +418,7 @@ namespace jiminy
         {
             // Generate a uniformly distributed random vector on n-sphere
             VectorN<double> dir;
-            for (uint_fast8_t i = 0; i < N; i += 2)
+            for (uint32_t i = 0; i < N; i += 2)
             {
                 // Generate 2 uniformly distributed random variables
                 const float u1 = static_cast<float>(hash) / fHashMax;

--- a/core/src/solver/constraint_solvers.cc
+++ b/core/src/solver/constraint_solvers.cc
@@ -2,7 +2,6 @@
 #include "pinocchio/multibody/data.hpp"      // `pinocchio::Data`
 #include "pinocchio/algorithm/cholesky.hpp"  // `pinocchio::cholesky::`
 
-#include "jiminy/core/utilities/random.h"
 #include "jiminy/core/utilities/helpers.h"
 #include "jiminy/core/constraints/abstract_constraint.h"
 #include "jiminy/core/robot/pinocchio_overload_algorithms.h"

--- a/core/src/utilities/random.cc
+++ b/core/src/utilities/random.cc
@@ -480,7 +480,7 @@ namespace jiminy
                             double orientation,
                             uint32_t seed)
     {
-        if ((0.01 < interpDelta.array()).any() || (interpDelta.array() > size.array() / 2.0).any())
+        if ((0.01 > interpDelta.array()).any() || (interpDelta.array() > size.array() / 2.0).any())
         {
             JIMINY_WARNING(
                 "All components of 'interpDelta' must be in range [0.01, 'size'/2.0]. Value: ",

--- a/core/src/utilities/random.cc
+++ b/core/src/utilities/random.cc
@@ -253,7 +253,7 @@ namespace jiminy
         Eigen::Index indexRight = indexLeft + 1;
 
         // Compute the time ratio
-        const double ratio = quot - indexLeft;
+        const double ratio = quot - static_cast<double>(indexLeft);
 
         return {indexLeft, indexRight, ratio};
     }
@@ -262,7 +262,7 @@ namespace jiminy
         double value, double delta, Eigen::Index numTimes)
     {
         // Wrap value in period interval
-        const double period = numTimes * delta;
+        const double period = static_cast<double>(numTimes) * delta;
         value = std::fmod(value, period);
         if (value < 0.0)
         {
@@ -403,7 +403,8 @@ namespace jiminy
         values_.noalias() += scale * cosMat_ * normalVec2;
 
         const auto diff =
-            2 * M_PI / period_ * Eigen::VectorXd::LinSpaced(numHarmonics_, 1, numHarmonics_);
+            2 * M_PI / period_ * Eigen::VectorXd::LinSpaced(
+                numHarmonics_, 1, static_cast<double>(numHarmonics_));
         grads_ = scale * cosMat_ * normalVec1.cwiseProduct(diff);
         grads_.noalias() -= scale * sinMat_ * normalVec2.cwiseProduct(diff);
     }

--- a/core/unit/CMakeLists.txt
+++ b/core/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ find_package(Threads)
 set(UNIT_TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/engine_sanity_check.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/model_test.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/random_test.cc"
     "${CMAKE_CURRENT_SOURCE_DIR}/miscellaneous.cc"
 )
 

--- a/core/unit/random_test.cc
+++ b/core/unit/random_test.cc
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+
+#include "jiminy/core/utilities/random.h"
+
+
+using namespace jiminy;
+
+static inline constexpr double DELTA{1e-6};
+static inline constexpr double TOL{1e-3};
+
+
+TEST(PerlinNoiseTest, RandomPerlinNoiseOctaveInitialization)
+{
+    double wavelength = 10.0;
+    RandomPerlinNoiseOctave<1> randomOctave(wavelength);
+
+    EXPECT_DOUBLE_EQ(randomOctave.getWavelength(), wavelength);
+}
+
+TEST(PerlinNoiseTest, PeriodicPerlinNoiseOctaveInitialization)
+{
+    double wavelength = 10.0;
+    double period = 20.0;
+    PeriodicPerlinNoiseOctave<1> periodicOctave(wavelength, period);
+
+    EXPECT_DOUBLE_EQ(periodicOctave.getWavelength(), wavelength);
+    EXPECT_DOUBLE_EQ(periodicOctave.getPeriod(), period);
+}
+
+TEST(PerlinNoiseTest, RandomGradientCalculation1D)
+{
+    {
+        double wavelength = 10.0;
+        RandomPerlinNoiseOctave<1> octave(wavelength);
+
+        Eigen::Array<double, 1, 1> t{5.43};
+        Eigen::Matrix<double, 1, 1> finiteDiffGrad{(octave(t + DELTA) - octave(t - DELTA)) /
+                                                   (2 * DELTA)};
+        ASSERT_TRUE(finiteDiffGrad.isApprox(octave.grad(t), TOL));
+    }
+    {
+        double wavelength = 3.41;
+        RandomPerlinNoiseOctave<1> octave(wavelength);
+
+        Eigen::Array<double, 1, 1> t{17.0};
+        Eigen::Matrix<double, 1, 1> finiteDiffGrad{(octave(t + DELTA) - octave(t - DELTA)) /
+                                                   (2 * DELTA)};
+        ASSERT_TRUE(finiteDiffGrad.isApprox(octave.grad(t), TOL));
+    }
+}
+
+TEST(PerlinNoiseTest, PeriodicGradientCalculation1D)
+{
+    double wavelength = 10.0;
+    double period = 30.0;
+    PeriodicPerlinNoiseOctave<1> octave(wavelength, period);
+
+    Eigen::Array<double, 1, 1> t{5.43};
+    Eigen::Matrix<double, 1, 1> finiteDiffGrad{(octave(t + DELTA) - octave(t - DELTA)) /
+                                               (2 * DELTA)};
+    ASSERT_TRUE(finiteDiffGrad.isApprox(octave.grad(t), TOL));
+}
+
+
+TEST(PerlinNoiseTest, RandomGradientCalculation2D)
+{
+    double wavelength = 10.0;
+    RandomPerlinNoiseOctave<2> octave(wavelength);
+
+    Eigen::Vector2d pos{5.43, 7.12};
+    Eigen::Vector2d finiteDiffGrad{(octave(pos + DELTA * Eigen::Vector2d::UnitX()) -
+                                    octave(pos - DELTA * Eigen::Vector2d::UnitX())) /
+                                       (2 * DELTA),
+                                   (octave(pos + DELTA * Eigen::Vector2d::UnitY()) -
+                                    octave(pos - DELTA * Eigen::Vector2d::UnitY())) /
+                                       (2 * DELTA)};
+    ASSERT_TRUE(finiteDiffGrad.isApprox(octave.grad(pos), TOL));
+}
+
+
+TEST(PerlinNoiseTest, PeriodicGradientCalculation2D)
+{
+    double wavelength = 10.0;
+    double period = 30.0;
+    PeriodicPerlinNoiseOctave<2> octave(wavelength, period);
+
+    Eigen::Vector2d pos{5.43, 7.12};
+    Eigen::Vector2d finiteDiffGrad{(octave(pos + DELTA * Eigen::Vector2d::UnitX()) -
+                                    octave(pos - DELTA * Eigen::Vector2d::UnitX())) /
+                                       (2 * DELTA),
+                                   (octave(pos + DELTA * Eigen::Vector2d::UnitY()) -
+                                    octave(pos - DELTA * Eigen::Vector2d::UnitY())) /
+                                       (2 * DELTA)};
+    ASSERT_TRUE(finiteDiffGrad.isApprox(octave.grad(pos), TOL));
+}

--- a/python/jiminy_pywrap/include/jiminy/python/utilities.h
+++ b/python/jiminy_pywrap/include/jiminy/python/utilities.h
@@ -812,8 +812,7 @@ namespace jiminy::python
     struct result_converter
     {
         template<typename T,
-                 typename = typename std::enable_if_t<copy || std::is_reference_v<T> ||
-                                                      is_eigen_ref_v<T>>>
+                 typename = std::enable_if_t<copy || std::is_reference_v<T> || is_eigen_ref_v<T>>>
         struct apply
         {
             struct type

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -96,7 +96,7 @@ namespace jiminy::python
     std::enable_if_t<std::conjunction_v<std::is_arithmetic<std::decay_t<Args>>...>, double>
     evaluatePerlinProcessUnpacked(DerivedPerlinProcess & fun, Args... args)
     {
-        return fun(Eigen::Matrix<double, sizeof...(Args), 1>{args...});
+        return fun(Eigen::Matrix<double, static_cast<int>(sizeof...(Args)), 1>{args...});
     }
 
     template<typename DerivedPerlinProcess, typename... Args>
@@ -104,7 +104,7 @@ namespace jiminy::python
                      typename DerivedPerlinProcess::template VectorN<double>>
     gradPerlinProcessUnpacked(DerivedPerlinProcess & fun, Args... args)
     {
-        return fun.grad(Eigen::Matrix<double, sizeof...(Args), 1>{args...});
+        return fun.grad(Eigen::Matrix<double, static_cast<int>(sizeof...(Args)), 1>{args...});
     }
 
     template<typename T, size_t>

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -256,6 +256,18 @@ namespace jiminy::python
         bp::def("periodic_stairs_ground",
                 &periodicStairs,
                 (bp::arg("step_width"), "step_height", "step_number", "orientation"));
+        bp::def("unidirectional_random_perlin_ground",
+                &unidirectionalRandomPerlinGround,
+                (bp::arg("wavelength"), "num_octaves", "orientation", "seed"));
+        bp::def("unidirectional_periodic_perlin_ground",
+                &unidirectionalPeriodicPerlinGround,
+                (bp::arg("wavelength"), "period", "num_octaves", "orientation", "seed"));
+        bp::def("random_perlin_ground",
+                &randomPerlinGround,
+                (bp::arg("wavelength"), "num_octaves", "seed"));
+        bp::def("periodic_perlin_ground",
+                &periodicPerlinGround,
+                (bp::arg("wavelength"), "period", "num_octaves", "seed"));
         bp::def("sum_heightmaps", &sumHeightmaps, (bp::arg("heightmaps")));
         bp::def("merge_heightmaps", &mergeHeightmaps, (bp::arg("heightmaps")));
 

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -95,15 +95,12 @@ namespace jiminy::python
 
     void exposeGenerators()
     {
-        // clang-format off
-        bp::class_<PCG32,
-                   std::shared_ptr<PCG32>,
-                   boost::noncopyable>("PCG32",
-                   bp::init<uint64_t>((bp::arg("self"), "state")))
+        bp::class_<PCG32, std::shared_ptr<PCG32>, boost::noncopyable>(
+            "PCG32", bp::init<uint64_t>((bp::arg("self"), "state")))
             .def(bp::init<>((bp::arg("self"))))
-            .def("__init__", bp::make_constructor(&makePCG32FromSeedSed,
-                             bp::default_call_policies(),
-                             (bp::arg("seed_seq"))))
+            .def("__init__",
+                 bp::make_constructor(
+                     &makePCG32FromSeedSed, bp::default_call_policies(), (bp::arg("seed_seq"))))
             .def("__call__", &PCG32::operator(), (bp::arg("self")))
             .def("seed", &seedPCG32FromSeedSed, (bp::arg("self"), "seed_seq"))
             .add_static_property(
@@ -113,93 +110,110 @@ namespace jiminy::python
 
         bp::implicitly_convertible<PCG32, uniform_random_bit_generator_ref<uint32_t>>();
 
-#define BIND_GENERIC_DISTRIBUTION(dist, arg1, arg2)                               \
-        bp::def(#dist, makeFunction(                                              \
-            ConvertGeneratorFromPythonAndInvoke(&dist##FromStackedArgs),          \
-            bp::default_call_policies(),                                          \
-            (bp::arg("generator"), #arg1, #arg2)));                               \
-        bp::def(#dist, makeFunction(                                              \
-            ConvertGeneratorFromPythonAndInvoke(&dist##FromSize),                 \
-            bp::default_call_policies(),                                          \
-            (bp::arg("generator"), bp::arg(#arg1) = 0.0F, bp::arg(#arg2) = 1.0F,  \
-             bp::arg("size") = bp::object())));
+#define BIND_GENERIC_DISTRIBUTION(dist, arg1, arg2)                                   \
+    bp::def(#dist,                                                                    \
+            makeFunction(ConvertGeneratorFromPythonAndInvoke(&dist##FromStackedArgs), \
+                         bp::default_call_policies(),                                 \
+                         (bp::arg("generator"), #arg1, #arg2)));                      \
+    bp::def(#dist,                                                                    \
+            makeFunction(ConvertGeneratorFromPythonAndInvoke(&dist##FromSize),        \
+                         bp::default_call_policies(),                                 \
+                         (bp::arg("generator"),                                       \
+                          bp::arg(#arg1) = 0.0F,                                      \
+                          bp::arg(#arg2) = 1.0F,                                      \
+                          bp::arg("size") = bp::object())));
 
-    BIND_GENERIC_DISTRIBUTION(uniform, lo, hi)
-    BIND_GENERIC_DISTRIBUTION(normal, mean, stddev)
+        BIND_GENERIC_DISTRIBUTION(uniform, lo, hi)
+        BIND_GENERIC_DISTRIBUTION(normal, mean, stddev)
 
 #undef BIND_GENERIC_DISTRIBUTION
 
         // Must be declared last to take precedence over generic declaration with default values
-        bp::def("uniform", makeFunction(ConvertGeneratorFromPythonAndInvoke(
-            static_cast<
-                float (*)(const uniform_random_bit_generator_ref<uint32_t> &)
-            >(&uniform)),
-            bp::default_call_policies(),
-            (bp::arg("generator"))));
+        bp::def("uniform",
+                makeFunction(
+                    ConvertGeneratorFromPythonAndInvoke(
+                        static_cast<float (*)(const uniform_random_bit_generator_ref<uint32_t> &)>(
+                            &uniform)),
+                    bp::default_call_policies(),
+                    (bp::arg("generator"))));
 
         bp::class_<PeriodicGaussianProcess,
                    std::shared_ptr<PeriodicGaussianProcess>,
-                   boost::noncopyable>("PeriodicGaussianProcess",
-                   bp::init<double, double>(
-                   (bp::arg("self"), "wavelength", "period")))
-            .def("__call__", &PeriodicGaussianProcess::operator(),
-                             (bp::arg("self"), bp::arg("time")))
-            .def("reset", makeFunction(
-                          ConvertGeneratorFromPythonAndInvoke(&PeriodicGaussianProcess::reset),
-                          bp::default_call_policies(),
-                          (bp::arg("self"), "generator")))
+                   boost::noncopyable>(
+            "PeriodicGaussianProcess",
+            bp::init<double, double>((bp::arg("self"), "wavelength", "period")))
+            .def("__call__",
+                 &PeriodicGaussianProcess::operator(),
+                 (bp::arg("self"), bp::arg("time")))
+            .def("reset",
+                 makeFunction(ConvertGeneratorFromPythonAndInvoke(&PeriodicGaussianProcess::reset),
+                              bp::default_call_policies(),
+                              (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET("wavelength", &PeriodicGaussianProcess::getWavelength)
             .ADD_PROPERTY_GET("period", &PeriodicGaussianProcess::getPeriod);
 
         bp::class_<PeriodicFourierProcess,
                    std::shared_ptr<PeriodicFourierProcess>,
-                   boost::noncopyable>("PeriodicFourierProcess",
-                   bp::init<double, double>(
-                   (bp::arg("self"), "wavelength", "period")))
-            .def("__call__", &PeriodicFourierProcess::operator(),
-                             (bp::arg("self"), bp::arg("time")))
-            .def("reset", makeFunction(
-                          ConvertGeneratorFromPythonAndInvoke(&PeriodicFourierProcess::reset),
-                          bp::default_call_policies(),
-                          (bp::arg("self"), "generator")))
+                   boost::noncopyable>(
+            "PeriodicFourierProcess",
+            bp::init<double, double>((bp::arg("self"), "wavelength", "period")))
+            .def("__call__",
+                 &PeriodicFourierProcess::operator(),
+                 (bp::arg("self"), bp::arg("time")))
+            .def("reset",
+                 makeFunction(ConvertGeneratorFromPythonAndInvoke(&PeriodicFourierProcess::reset),
+                              bp::default_call_policies(),
+                              (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET("wavelength", &PeriodicFourierProcess::getWavelength)
             .ADD_PROPERTY_GET("period", &PeriodicFourierProcess::getPeriod);
 
         bp::class_<AbstractPerlinProcess,
                    std::shared_ptr<AbstractPerlinProcess>,
                    boost::noncopyable>("AbstractPerlinProcess", bp::no_init)
-            .def("__call__", &AbstractPerlinProcess::operator(),
-                             (bp::arg("self"), "time"))
-            .def("reset", makeFunction(
-                          ConvertGeneratorFromPythonAndInvoke(&AbstractPerlinProcess::reset),
-                          bp::default_call_policies(),
-                          (bp::arg("self"), "generator")))
+            .def("__call__", &AbstractPerlinProcess::operator(), (bp::arg("self"), "time"))
+            .def("reset",
+                 makeFunction(ConvertGeneratorFromPythonAndInvoke(&AbstractPerlinProcess::reset),
+                              bp::default_call_policies(),
+                              (bp::arg("self"), "generator")))
             .ADD_PROPERTY_GET("wavelength", &AbstractPerlinProcess::getWavelength)
             .ADD_PROPERTY_GET("num_octaves", &AbstractPerlinProcess::getNumOctaves);
 
-        bp::class_<RandomPerlinProcess, bp::bases<AbstractPerlinProcess>,
+        bp::class_<RandomPerlinProcess,
+                   bp::bases<AbstractPerlinProcess>,
                    std::shared_ptr<RandomPerlinProcess>,
-                   boost::noncopyable>("RandomPerlinProcess",
-                   bp::init<double, uint32_t>(
-                   (bp::arg("self"), "wavelength", bp::arg("num_octaves") = 6U)));
+                   boost::noncopyable>(
+            "RandomPerlinProcess",
+            bp::init<double, uint32_t>(
+                (bp::arg("self"), "wavelength", bp::arg("num_octaves") = 6U)));
 
-        bp::class_<PeriodicPerlinProcess, bp::bases<AbstractPerlinProcess>,
+        bp::class_<PeriodicPerlinProcess,
+                   bp::bases<AbstractPerlinProcess>,
                    std::shared_ptr<PeriodicPerlinProcess>,
-                   boost::noncopyable>("PeriodicPerlinProcess",
-                   bp::init<double, double, uint32_t>(
-                   (bp::arg("self"), "wavelength", "period", bp::arg("num_octaves") = 6U)))
+                   boost::noncopyable>(
+            "PeriodicPerlinProcess",
+            bp::init<double, double, uint32_t>(
+                (bp::arg("self"), "wavelength", "period", bp::arg("num_octaves") = 6U)))
             .ADD_PROPERTY_GET("period", &PeriodicPerlinProcess::getPeriod);
 
-        bp::def("random_tile_ground", &tiles,
-                                      (bp::arg("size"), "height_max", "interp_delta",
-                                       "sparsity", "orientation", "seed"));
-        bp::def("stairs_ground", &stairs, (bp::arg("step_width"), "step_height", "step_number", "orientation"));
+        bp::def(
+            "random_tile_ground",
+            &tiles,
+            (bp::arg("size"), "height_max", "interp_delta", "sparsity", "orientation", "seed"));
+        bp::def("periodic_stairs_ground",
+                &periodicStairs,
+                (bp::arg("step_width"), "step_height", "step_number", "orientation"));
         bp::def("sum_heightmaps", &sumHeightmaps, (bp::arg("heightmaps")));
         bp::def("merge_heightmaps", &mergeHeightmaps, (bp::arg("heightmaps")));
 
-        bp::def("discretize_heightmap", &discretizeHeightmap,
-                                        (bp::arg("heightmap"), "x_min", "x_max", "x_unit", "y_min",
-                                         "y_max", "y_unit", bp::arg("must_simplify") = false));
-        // clang-format on
+        bp::def("discretize_heightmap",
+                &discretizeHeightmap,
+                (bp::arg("heightmap"),
+                 "x_min",
+                 "x_max",
+                 "x_unit",
+                 "y_min",
+                 "y_max",
+                 "y_unit",
+                 bp::arg("must_simplify") = false));
     }
 }

--- a/python/jiminy_pywrap/src/generators.cc
+++ b/python/jiminy_pywrap/src/generators.cc
@@ -142,9 +142,8 @@ namespace jiminy::python
                    boost::noncopyable>(
             "PeriodicGaussianProcess",
             bp::init<double, double>((bp::arg("self"), "wavelength", "period")))
-            .def("__call__",
-                 &PeriodicGaussianProcess::operator(),
-                 (bp::arg("self"), bp::arg("time")))
+            .def("__call__", &PeriodicGaussianProcess::operator(), (bp::arg("self"), "time"))
+            .def("gradient", &PeriodicGaussianProcess::gradient, (bp::arg("self"), "time"))
             .def("reset",
                  makeFunction(ConvertGeneratorFromPythonAndInvoke(&PeriodicGaussianProcess::reset),
                               bp::default_call_policies(),
@@ -157,9 +156,8 @@ namespace jiminy::python
                    boost::noncopyable>(
             "PeriodicFourierProcess",
             bp::init<double, double>((bp::arg("self"), "wavelength", "period")))
-            .def("__call__",
-                 &PeriodicFourierProcess::operator(),
-                 (bp::arg("self"), bp::arg("time")))
+            .def("__call__", &PeriodicFourierProcess::operator(), (bp::arg("self"), "time"))
+            .def("gradient", &PeriodicFourierProcess::gradient, (bp::arg("self"), "time"))
             .def("reset",
                  makeFunction(ConvertGeneratorFromPythonAndInvoke(&PeriodicFourierProcess::reset),
                               bp::default_call_policies(),


### PR DESCRIPTION
I am proposing to add a unidirection Perlin ground `HeightmapFunction`, 2D Perlin ground `HeightmapFunction` and a quantization methods to quantize any ground to certain z-values. 


- [x] Unidirectional Perlin Ground: 

<img width="870" alt="periodicperlinground" src="https://github.com/duburcqa/jiminy/assets/101942083/2323f427-09fc-45e2-95b7-69ce70fdf9e3">

- [x] 2D Perlin Ground
<img width="1274" alt="2D_random_perlin_ground" src="https://github.com/duburcqa/jiminy/assets/101942083/bd406bdf-862f-4403-bcac-137e3304bd08">

- [x] Pass the Perlin process by copy to the builder function
- [ ] Ground quantization method to quantized the ground to only certain level
- [ ] Unit tests
- [ ] Fix sample_state in gym-jiminy to account for the ground profile ?