### PR TITLE
[python|gym] Add contraint lambda multipliers to state and extracted trajectory.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -71,6 +71,7 @@ disable =
     useless-parent-delegation,
     use-dict-literal,
     unspecified-encoding,
+    undefined-loop-variable,
     cyclic-import
 
 # Enable the message, report, category or checker with the given id(s)

--- a/core/include/jiminy/core/constraints/abstract_constraint.h
+++ b/core/include/jiminy/core/constraints/abstract_constraint.h
@@ -55,7 +55,7 @@ namespace jiminy
         virtual const std::string & getType() const = 0;
 
         /// \brief Dimension of the constraint.
-        uint64_t getDim() const;
+        uint64_t getSize() const;
 
         /// \brief Jacobian of the constraint.
         const Eigen::MatrixXd & getJacobian() const;

--- a/core/include/jiminy/core/engine/engine.h
+++ b/core/include/jiminy/core/engine/engine.h
@@ -201,6 +201,7 @@ namespace jiminy
         std::vector<std::string> logAccelerationFieldnames{};
         std::vector<std::string> logEffortFieldnames{};
         std::vector<std::string> logForceExternalFieldnames{};
+        std::vector<std::string> logConstraintFieldnames{};
         std::vector<std::string> logCommandFieldnames{};
         std::string logEnergyFieldname{};
 
@@ -329,6 +330,7 @@ namespace jiminy
             config["enableVelocity"] = true;
             config["enableAcceleration"] = true;
             config["enableForceExternal"] = false;
+            config["enableConstraint"] = false;
             config["enableCommand"] = false;
             config["enableEffort"] = false;
             config["enableEnergy"] = false;
@@ -438,6 +440,7 @@ namespace jiminy
             const bool enableVelocity;
             const bool enableAcceleration;
             const bool enableForceExternal;
+            const bool enableConstraint;
             const bool enableCommand;
             const bool enableEffort;
             const bool enableEnergy;
@@ -448,6 +451,7 @@ namespace jiminy
             enableVelocity{boost::get<bool>(options.at("enableVelocity"))},
             enableAcceleration{boost::get<bool>(options.at("enableAcceleration"))},
             enableForceExternal{boost::get<bool>(options.at("enableForceExternal"))},
+            enableConstraint{boost::get<bool>(options.at("enableConstraint"))},
             enableCommand{boost::get<bool>(options.at("enableCommand"))},
             enableEffort{boost::get<bool>(options.at("enableEffort"))},
             enableEnergy{boost::get<bool>(options.at("enableEnergy"))}

--- a/core/include/jiminy/core/robot/model.h
+++ b/core/include/jiminy/core/robot/model.h
@@ -21,6 +21,8 @@ namespace jiminy
     class AbstractConstraintBase;
     class FrameConstraint;
     class JointConstraint;
+    class MutexLocal;
+    class LockGuardLocal;
 
     // ************************************** Constraints ************************************** //
 
@@ -371,6 +373,7 @@ namespace jiminy
         const std::vector<std::string> & getLogAccelerationFieldnames() const;
         const std::vector<std::string> & getLogEffortFieldnames() const;
         const std::vector<std::string> & getLogForceExternalFieldnames() const;
+        const std::vector<std::string> & getLogConstraintFieldnames() const;
 
         void getExtendedPositionFromTheoretical(const Eigen::VectorXd & qTheoretical,
                                                 Eigen::VectorXd & qExtended) const;
@@ -380,6 +383,9 @@ namespace jiminy
                                                 Eigen::VectorXd & qTheoretical) const;
         void getTheoreticalVelocityFromExtended(const Eigen::VectorXd & vExtended,
                                                 Eigen::VectorXd & vTheoretical) const;
+
+        virtual std::unique_ptr<LockGuardLocal> getLock();
+        bool getIsLocked() const;
 
     protected:
         void generateModelExtended(const uniform_random_bit_generator_ref<uint32_t> & g);
@@ -405,8 +411,6 @@ namespace jiminy
 
         void refreshGeometryProxies();
         void refreshContactProxies();
-        /// \brief Refresh the proxies of the kinematics constraints.
-        void refreshConstraintProxies();
         virtual void refreshProxies();
 
     public:
@@ -476,8 +480,12 @@ namespace jiminy
         /// \brief Concatenated fieldnames of the external force applied at each joint of the
         ///        model, 'universe' excluded.
         std::vector<std::string> logForceExternalFieldnames_{};
+        /// \brief Concatenated fieldnames of all the constraints.
+        std::vector<std::string> logConstraintFieldnames_{};
 
     private:
+        std::unique_ptr<MutexLocal> mutexLocal_{std::make_unique<MutexLocal>()};
+
         /// \brief Vector of joints acceleration corresponding to a copy of data.a.
         //         Used for computing constraints as a temporary buffer.
         MotionVector jointSpatialAccelerations_{};

--- a/core/include/jiminy/core/robot/pinocchio_overload_algorithms.h
+++ b/core/include/jiminy/core/robot/pinocchio_overload_algorithms.h
@@ -46,9 +46,9 @@ namespace jiminy::pinocchio_overload
                          pinocchio::DataTpl<Scalar, Options, JointCollectionTpl> & data,
                          const Eigen::MatrixBase<ConfigVectorType> & q,
                          const Eigen::MatrixBase<TangentVectorType> & v,
-                         bool update_kinematics = true)
+                         bool updateKinematics = true)
     {
-        if (update_kinematics)
+        if (updateKinematics)
         {
             pinocchio::forwardKinematics(model, data, q, v);
         }

--- a/core/include/jiminy/core/robot/robot.h
+++ b/core/include/jiminy/core/robot/robot.h
@@ -15,8 +15,6 @@ namespace jiminy
     class AbstractSensorBase;
     class AbstractController;
     class TelemetryData;
-    class MutexLocal;
-    class LockGuardLocal;
 
     class JIMINY_DLLAPI Robot : public Model
     {
@@ -115,15 +113,14 @@ namespace jiminy
 
         /// \remark This method does not have to be called manually before running a simulation.
         ///         The Engine is taking care of it.
-        virtual void reset(const uniform_random_bit_generator_ref<uint32_t> & g) override;
+        void reset(const uniform_random_bit_generator_ref<uint32_t> & g) override;
         virtual void configureTelemetry(std::shared_ptr<TelemetryData> telemetryData);
         void updateTelemetry();
         bool getIsTelemetryConfigured() const;
 
         const std::vector<std::string> & getLogCommandFieldnames() const;
 
-        std::unique_ptr<LockGuardLocal> getLock();
-        bool getIsLocked() const;
+        std::unique_ptr<LockGuardLocal> getLock() override;
 
         // Getters without 'get' prefix for consistency with pinocchio C++ API
         Eigen::Index nmotors() const;
@@ -161,7 +158,6 @@ namespace jiminy
         Eigen::VectorXd motorEffortLimit_;
 
     private:
-        std::unique_ptr<MutexLocal> mutexLocal_{std::make_unique<MutexLocal>()};
         std::shared_ptr<MotorSharedStorage> motorSharedStorage_;
         std::unordered_map<std::string, std::shared_ptr<SensorSharedStorage>>
             sensorSharedStorageMap_{};

--- a/core/src/constraints/abstract_constraint.cc
+++ b/core/src/constraints/abstract_constraint.cc
@@ -109,7 +109,7 @@ namespace jiminy
         return zeta / (2.0 * M_PI);
     }
 
-    uint64_t AbstractConstraintBase::getDim() const
+    uint64_t AbstractConstraintBase::getSize() const
     {
         return static_cast<uint64_t>(drift_.size());
     }

--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -1256,10 +1256,10 @@ namespace jiminy
                 [&contactModel = contactModel_,
                  &freq = engineOptions_->contacts.stabilizationFreq](
                     const std::shared_ptr<AbstractConstraintBase> & constraint,
-                    ConstraintNodeType node)
+                    ConstraintRegistryType type)
                 {
                     // Set baumgarte freq for all contact constraints
-                    if (node != ConstraintNodeType::USER)
+                    if (type != ConstraintRegistryType::USER)
                     {
                         constraint->setBaumgarteFreq(freq);  // It cannot fail
                     }
@@ -1267,20 +1267,20 @@ namespace jiminy
                     // Enable constraints by default
                     if (contactModel == ContactModelType::CONSTRAINT)
                     {
-                        switch (node)
+                        switch (type)
                         {
-                        case ConstraintNodeType::BOUNDS_JOINTS:
+                        case ConstraintRegistryType::BOUNDS_JOINTS:
                         {
                             auto & jointConstraint =
                                 static_cast<JointConstraint &>(*constraint.get());
                             jointConstraint.setRotationDir(false);
                         }
                             [[fallthrough]];
-                        case ConstraintNodeType::CONTACT_FRAMES:
-                        case ConstraintNodeType::COLLISION_BODIES:
+                        case ConstraintRegistryType::CONTACT_FRAMES:
+                        case ConstraintRegistryType::COLLISION_BODIES:
                             constraint->enable();
                             break;
-                        case ConstraintNodeType::USER:
+                        case ConstraintRegistryType::USER:
                         default:
                             break;
                         }
@@ -3738,12 +3738,12 @@ namespace jiminy
             // Restore contact frame forces and bounds internal efforts
             const ConstraintTree & constraints = robot->getConstraints();
             constraints.foreach(
-                ConstraintNodeType::BOUNDS_JOINTS,
+                ConstraintRegistryType::BOUNDS_JOINTS,
                 [&u = robotData.state.u,
                  &uInternal = robotData.state.uInternal,
                  &joints = const_cast<pinocchio::Model::JointModelVector &>(model.joints)](
                     const std::shared_ptr<AbstractConstraintBase> & constraint,
-                    ConstraintNodeType /* node */)
+                    ConstraintRegistryType /* type */)
                 {
                     if (!constraint->getIsEnabled())
                     {
@@ -3794,9 +3794,9 @@ namespace jiminy
             }
 
             constraints.foreach(
-                ConstraintNodeType::COLLISION_BODIES,
+                ConstraintRegistryType::COLLISION_BODIES,
                 [&fext, &model, &data](const std::shared_ptr<AbstractConstraintBase> & constraint,
-                                       ConstraintNodeType /* node */)
+                                       ConstraintRegistryType /* type */)
                 {
                     if (!constraint->getIsEnabled())
                     {

--- a/core/src/io/serialization.cc
+++ b/core/src/io/serialization.cc
@@ -871,7 +871,7 @@ namespace boost::serialization
                  ++meshPathIt)
             {
                 const std::string meshPath = meshPathIt->str();
-                if (meshPath.compare(0, packagePrefix.size(), packagePrefix) != 0)
+                if (!meshPath.compare(0, packagePrefix.size(), packagePrefix))
                 {
                     meshPaths.emplace_back(meshPath);
                 }

--- a/core/src/robot/robot.cc
+++ b/core/src/robot/robot.cc
@@ -592,7 +592,7 @@ namespace jiminy
             std::string backlashName = jointName;
             backlashName += BACKLASH_JOINT_SUFFIX;
 
-            // Check if constraint a joint bounds constraint exist
+            // Check if the corresponding joint bound constraint already exists
             const bool hasConstraint =
                 constraints_.exist(backlashName, ConstraintRegistryType::BOUNDS_JOINTS);
 
@@ -605,9 +605,12 @@ namespace jiminy
                 {
                     removeConstraint(backlashName, ConstraintRegistryType::BOUNDS_JOINTS);
                 }
-
                 continue;
             }
+
+            // Add backlash joint to the model
+            addBacklashJointAfterMechanicalJoint(pinocchioModel_, jointName, backlashName);
+            backlashJointNames_.push_back(backlashName);
 
             // Add joint bounds constraint if necessary
             if (!hasConstraint)
@@ -616,10 +619,6 @@ namespace jiminy
                     std::make_shared<JointConstraint>(backlashName);
                 addConstraint(backlashName, constraint, ConstraintRegistryType::BOUNDS_JOINTS);
             }
-
-            // Add backlash joint to the model
-            addBacklashJointAfterMechanicalJoint(pinocchioModel_, jointName, backlashName);
-            backlashJointNames_.push_back(backlashName);
 
             // Update position limits in model
             const Eigen::Index positionIndex =

--- a/core/src/robot/robot.cc
+++ b/core/src/robot/robot.cc
@@ -1050,24 +1050,15 @@ namespace jiminy
 
     std::unique_ptr<LockGuardLocal> Robot::getLock()
     {
-        // Make sure that the robot is not already locked
-        if (mutexLocal_->isLocked())
-        {
-            JIMINY_THROW(bad_control_flow,
-                         "Robot already locked. Please release it first prior requesting lock.");
-        }
+        // Get lock
+        std::unique_ptr<LockGuardLocal> lock = Model::getLock();
 
         // Make sure that the options are not already considered valid as it was impossible to
         // guarantee it before locking the robot.
         areRobotOptionsRefreshed_ = false;
 
         // Return lock
-        return std::make_unique<LockGuardLocal>(*mutexLocal_);
-    }
-
-    bool Robot::getIsLocked() const
-    {
-        return mutexLocal_->isLocked();
+        return lock;
     }
 
     Eigen::Index Robot::nmotors() const

--- a/core/src/robot/robot.cc
+++ b/core/src/robot/robot.cc
@@ -594,7 +594,7 @@ namespace jiminy
 
             // Check if constraint a joint bounds constraint exist
             const bool hasConstraint =
-                constraints_.exist(backlashName, ConstraintNodeType::BOUNDS_JOINTS);
+                constraints_.exist(backlashName, ConstraintRegistryType::BOUNDS_JOINTS);
 
             // Skip adding joint if no backlash
             const double backlash = motor->getBacklash();
@@ -603,7 +603,7 @@ namespace jiminy
                 // Remove joint bounds constraint if any
                 if (hasConstraint)
                 {
-                    removeConstraint(backlashName, ConstraintNodeType::BOUNDS_JOINTS);
+                    removeConstraint(backlashName, ConstraintRegistryType::BOUNDS_JOINTS);
                 }
 
                 continue;
@@ -614,7 +614,7 @@ namespace jiminy
             {
                 std::shared_ptr<AbstractConstraintBase> constraint =
                     std::make_shared<JointConstraint>(backlashName);
-                addConstraint(backlashName, constraint, ConstraintNodeType::BOUNDS_JOINTS);
+                addConstraint(backlashName, constraint, ConstraintRegistryType::BOUNDS_JOINTS);
             }
 
             // Add backlash joint to the model

--- a/core/src/utilities/random.cc
+++ b/core/src/utilities/random.cc
@@ -347,7 +347,10 @@ namespace jiminy
     AbstractPerlinNoiseOctave::AbstractPerlinNoiseOctave(double wavelength) :
     wavelength_{wavelength}
     {
-        assert(wavelength_ > 0 && "wavelength must be strictly larger than 0.0.");
+        if (wavelength_ <= 0.0)
+        {
+            JIMINY_THROW(std::invalid_argument, "'wavelength' must be strictly larger than 0.0.");
+        }
         shift_ = uniform(std::random_device{});
     }
 
@@ -447,8 +450,11 @@ namespace jiminy
     period_{period}
     {
         // Make sure the wavelength is multiple of the period
-        assert(std::abs(std::round(period / wavelength) * wavelength - period) < 1e-6 &&
-               "wavelength must be multiple of period.");
+        if (std::abs(std::round(period / wavelength) * wavelength - period) >
+            std::numeric_limits<float>::epsilon())
+        {
+            JIMINY_THROW(std::invalid_argument, "'wavelength' must be multiple of 'period'.");
+        }
 
         // Initialize the permutation vector with values from 0 to 255 and shuffle it
         internal::randomizePermutationVector(std::random_device{}, perm_);
@@ -569,7 +575,10 @@ namespace jiminy
     period_{period}
     {
         // Make sure the period is larger than the wavelength
-        assert(period_ >= wavelength && "Period must be larger than wavelength.");
+        if (period_ < wavelength)
+        {
+            JIMINY_THROW(std::invalid_argument, "'period' must be larger than 'wavelength'.");
+        }
     }
 
     double PeriodicPerlinProcess::getPeriod() const noexcept

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
@@ -471,7 +471,7 @@ class InterfaceQuantity(ABC, Generic[ValueT]):
         if (not ignore_auto_refresh and self.auto_refresh and
                 not self.has_cache):
             raise RuntimeError(
-                "Automatic refresh enabled but no shared cache available. "
+                "Automatic refresh enabled but no shared cache is available. "
                 "Please add one before calling this method.")
 
         # Reset all requirements first
@@ -994,7 +994,7 @@ class StateQuantity(InterfaceQuantity[State]):
             else:
                 f_external_batch = np.array([])
             self.state = State(
-                self.env.stepper_state.t,
+                0.0,
                 self.env.robot_state.q,
                 self.env.robot_state.v,
                 self.env.robot_state.a,
@@ -1039,6 +1039,7 @@ class StateQuantity(InterfaceQuantity[State]):
         """
         # Update state at which the quantity must be evaluated
         if self.mode == QuantityEvalMode.TRUE:
+            self.state.t = self.env.stepper_state.t
             multi_array_copyto(self._f_external_slices, self._f_external_list)
         else:
             self.state = self.trajectory.get()

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
@@ -296,6 +296,14 @@ class InterfaceQuantity(ABC, Generic[ValueT]):
             name: cls(env, self, **kwargs)
             for name, (cls, kwargs) in requirements.items()}
 
+        # Update the state explicitly if available but auto-refresh not enabled
+        self._state: Optional[StateQuantity] = None
+        if isinstance(self, AbstractQuantity):
+            quantity = self.requirements["state"]
+            if not quantity.auto_refresh:
+                assert isinstance(quantity, StateQuantity)
+                self._state = quantity
+
         # Shared cache handling
         self._cache: Optional[SharedCache[ValueT]] = None
         self.has_cache = False
@@ -423,10 +431,17 @@ class InterfaceQuantity(ABC, Generic[ValueT]):
 
         # Evaluate quantity
         try:
+            # Initialize quantity
             if not self._is_initialized:
                 self.initialize()
                 assert (self._is_initialized and
                         self._is_active)  # type: ignore[unreachable]
+
+            # Make sure that the state has been refreshed
+            if self._state is not None:
+                self._state.get()
+
+            # Refresh quantity
             value = self.refresh()
         except RecursionError as e:
             raise LookupError(
@@ -611,13 +626,23 @@ class AbstractQuantity(InterfaceQuantity, Generic[ValueT]):
 
         # Make sure that no user-specified requirement is named 'trajectory'
         requirement_names = requirements.keys()
-        if any(name in requirement_names for name in ("state", "trajectory")):
+        if "trajectory" in requirement_names:
             raise ValueError(
-                "No user-specified requirement can be named 'state' nor "
-                "'trajectory' as these keys are reserved.")
+                "Key 'trajectory' is reserved and cannot be used for "
+                "user-specified requirements.")
 
-        # Add state quantity as requirement
-        requirements["state"] = (StateQuantity, dict(mode=mode))
+        # Make sure that state requirement is valid if any or use default
+        quantity = requirements.get("state")
+        if quantity is not None:
+            cls, kwargs = quantity
+            if (not issubclass(cls, StateQuantity) or
+                    kwargs.setdefault("mode", mode) != mode):
+                raise ValueError(
+                    "Key 'state' is reserved and can only be used to specify "
+                    "a `StateQuantity` requirement, as a way to give the "
+                    "opportunity to overwrite 'update_*' default arguments.")
+        else:
+            requirements["state"] = (StateQuantity, dict(mode=mode))
 
         # Call base implementation
         super().__init__(env, parent, requirements, auto_refresh=auto_refresh)
@@ -905,7 +930,12 @@ class StateQuantity(InterfaceQuantity[State]):
                  env: InterfaceJiminyEnv,
                  parent: Optional[InterfaceQuantity],
                  *,
-                 mode: QuantityEvalMode = QuantityEvalMode.TRUE) -> None:
+                 mode: QuantityEvalMode = QuantityEvalMode.TRUE,
+                 update_kinematics: bool = True,
+                 update_dynamics: bool = False,
+                 update_centroidal: bool = False,
+                 update_energy: bool = False,
+                 update_jacobian: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param parent: Higher-level quantity from which this quantity is a
@@ -917,12 +947,66 @@ class StateQuantity(InterfaceQuantity[State]):
                      some reference trajectory at the current simulation time
                      will be used instead.
                      Optional: 'QuantityEvalMode.TRUE' by default.
+        :param update_kinematics: Whether to update body and frame transforms,
+                                  spatial velocities and accelerations stored
+                                  in `self.pinocchio_data` if necessary to be
+                                  consistent with the current state of the
+                                  robot. This argument has no effect if mode is
+                                  set to `QuantityEvalMode.TRUE` because this
+                                  property is already guarantee.
+                                  Optional: False by default.
+        :param update_dynamics: Whether to update the non-linear effects and
+                                the joint internal forces stored in
+                                `self.pinocchio_data` if necessary.
+                                Optional: False by default.
+        :param update_centroidal: Whether to update the centroidal dynamics
+                                  (incl. CoM) stored in `self.pinocchio_data`
+                                  if necessary.
+                                  Optional: True by default.
+        :param update_energy: Whether to update the potential and kinematic
+                              energy stored in `self.pinocchio_data` if
+                              necessary.
+                              Optional: False by default.
+        :param update_jacobian: Whether to update the joint Jacobian matrices
+                                stored in `self.pinocchio_data` if necessary.
+                                Optional: False by default.
         """
+        # Make sure that the input arguments are valid
+        update_kinematics = (
+            update_kinematics or update_dynamics or update_centroidal or
+            update_energy or update_jacobian)
+
         # Backup user argument(s)
         self.mode = mode
+        self.update_kinematics = update_kinematics
+        self.update_dynamics = update_dynamics
+        self.update_centroidal = update_centroidal
+        self.update_energy = update_energy
+        self.update_jacobian = update_jacobian
 
-        # Call base implementation
-        super().__init__(env, parent, requirements={}, auto_refresh=True)
+        # Enable auto-refresh based on the evaluation mode
+        # Note that it is necessary to auto-refresh this quantity, as it is the
+        # one responsible for making sure that dynamics quantities are always
+        # up-to-date when refreshing quantities. The latter are involved one
+        # way of the other in the computation of any quantity, which means that
+        # pre-computing it does not induce any unnecessary computations as long
+        # as the user fetches the value of at least one quantity. Although this
+        # assumption is very likely to be true at the step update period, it is
+        # not the case at the observer update period. It sounds more efficient
+        # refresh to the state the first time any quantity gets computed.
+        # However, systematically checking if the state must be refreshed for
+        # all quantities adds overheat and may be fairly costly overall. The
+        # optimal trade-off is to rely on auto-refresh if the evaluation mode
+        # is TRUE, since refreshing the state only consists in copying some
+        # data, which is very cheap. On the contrary, it is more efficient to
+        # only refresh the state when needed if the evaluation mode is TRAJ.
+        # * Update state: 500ns (TRUE) | 5.0us (TRAJ)
+        # * Check cache state: 70ns
+        auto_refresh = mode == QuantityEvalMode.TRUE
+
+        # Call base implementation.
+        super().__init__(
+            env, parent, requirements={}, auto_refresh=auto_refresh)
 
         # Create empty trajectory database, manually added as a requirement.
         # Note that it must be done after base initialization, otherwise a
@@ -936,12 +1020,16 @@ class StateQuantity(InterfaceQuantity[State]):
         self.pinocchio_data = env.robot.pinocchio_data
 
         # State for which the quantity must be evaluated
-        self._f_external_slices: List[np.ndarray] = []
-        self._f_external_list: List[np.ndarray] = []
         self.state = State(t=np.nan, q=np.array([]))
 
+        # Persistent buffer for storing body external forces if necessary
+        self._f_external_vec = pin.StdVec_Force()
+        self._f_external_list: List[np.ndarray] = []
+        self._f_external_batch = np.array([])
+        self._f_external_slices: List[np.ndarray] = []
+
         # Persistent buffer storing all lambda multipliers for efficiency
-        self._constraint_lambda_all = np.array({})
+        self._constraint_lambda_batch = np.array([])
 
         # Slices in stacked lambda multiplier flat vector
         self._constraint_lambda_slices: List[np.ndarray] = []
@@ -949,7 +1037,30 @@ class StateQuantity(InterfaceQuantity[State]):
         # Lambda multipliers of all the constraints individually
         self._constraint_lambda_list: List[np.ndarray] = []
 
+        # Whether to update kinematic and dynamic data to be consistent with
+        # the current state of the robot, based on the requirement of all the
+        # co-owners of shared cache.
+        self._update_kinematics = False
+        self._update_dynamics = False
+        self._update_centroidal = False
+        self._update_energy = False
+        self._update_jacobian = False
+
     def initialize(self) -> None:
+        # Determine which data must be update based on shared cache co-owners
+        owners = self.cache.owners if self.has_cache else (self,)
+        self._update_kinematics = False
+        self._update_dynamics = False
+        self._update_centroidal = False
+        self._update_energy = False
+        self._update_jacobian = False
+        for owner in owners:
+            self._update_kinematics |= owner.update_kinematics
+            self._update_dynamics |= owner.update_dynamics
+            self._update_centroidal |= owner.update_centroidal
+            self._update_energy |= owner.update_energy
+            self._update_jacobian |= owner.update_jacobian
+
         # Refresh robot and pinocchio proxies for co-owners of shared cache.
         # Note that automatic refresh is not sufficient to guarantee that
         # `initialize` will be called unconditionally, because it will be
@@ -959,7 +1070,6 @@ class StateQuantity(InterfaceQuantity[State]):
         # instance to found the cache empty. Only the necessary bits are
         # synchronized instead of the whole method, to avoid messing up with
         # computation graph tracking.
-        owners = self.cache.owners if self.has_cache else (self,)
         for owner in owners:
             assert isinstance(owner, StateQuantity)
             if owner._is_initialized:
@@ -981,18 +1091,53 @@ class StateQuantity(InterfaceQuantity[State]):
         # The quantity will be considered initialized and active at this point.
         super().initialize()
 
-        # Define the state for which the quantity must be evaluated
+        # Refresh proxies and allocate memory for storing external forces
         if self.mode == QuantityEvalMode.TRUE:
-            # Refresh mapping from robot state to quantity buffer
+            self._f_external_vec = self.env.robot_state.f_external
+        else:
+            self._f_external_vec = pin.StdVec_Force()
+            self._f_external_vec.extend([
+                pin.Force() for _ in range(self.pinocchio_model.njoints)])
+        self._f_external_list = [
+            f_ext.vector for f_ext in self._f_external_vec]
+        self._f_external_batch = np.zeros((self.pinocchio_model.njoints, 6))
+        self._f_external_slices = list(self._f_external_batch)
+
+        # Allocate memory for lambda vector
+        self._constraint_lambda_batch = np.zeros(
+            (len(self.robot.log_constraint_fieldnames),))
+
+        # Refresh mapping from lambda multipliers to corresponding slice
+        self._constraint_lambda_list.clear()
+        self._constraint_lambda_slices.clear()
+        constraint_lookup_pairs = tuple(
+            (f"Constraint{registry_type}", registry)
+            for registry_type, registry in (
+                ("BoundJoints", self.robot.constraints.bounds_joints),
+                ("ContactFrames", self.robot.constraints.contact_frames),
+                ("CollisionBodies", {
+                    name: constraint for constraints in (
+                        self.robot.constraints.collision_bodies)
+                    for name, constraint in constraints.items()}),
+                ("User", self.robot.constraints.user)))
+        i = 0
+        while i < len(self.robot.log_constraint_fieldnames):
+            fieldname = self.robot.log_constraint_fieldnames[i]
+            for registry_type, registry in constraint_lookup_pairs:
+                if fieldname.startswith(registry_type):
+                    break
+            constraint_name = fieldname[len(registry_type):-1]
+            constraint = registry[constraint_name]
+            self._constraint_lambda_list.append(constraint.lambda_c)
+            self._constraint_lambda_slices.append(
+                self._constraint_lambda_batch[i:(i + constraint.size)])
+            i += constraint.size
+
+        # Allocate state for which the quantity must be evaluated if needed
+        if self.mode == QuantityEvalMode.TRUE:
             if not self.env.is_simulation_running:
                 raise RuntimeError("No simulation running. Impossible to "
                                    "initialize this quantity.")
-            self._f_external_list = [
-                f_ext.vector for f_ext in self.env.robot_state.f_external]
-            if self._f_external_list:
-                f_external_batch = np.stack(self._f_external_list, axis=0)
-            else:
-                f_external_batch = np.array([])
             self.state = State(
                 0.0,
                 self.env.robot_state.q,
@@ -1000,38 +1145,7 @@ class StateQuantity(InterfaceQuantity[State]):
                 self.env.robot_state.a,
                 self.env.robot_state.u,
                 self.env.robot_state.command,
-                f_external_batch)
-            self._f_external_slices = list(f_external_batch)
-        else:
-            # Allocate memory for lambda vector
-            self._constraint_lambda_all = np.zeros(
-                (len(self.robot.log_constraint_fieldnames),))
-
-            # Refresh mapping from lambda multipliers to corresponding slice
-            self._constraint_lambda_list.clear()
-            self._constraint_lambda_slices.clear()
-            constraint_lookup_pairs = tuple(
-                (f"Constraint{registry_type}", registry)
-                for registry_type, registry in (
-                    ("BoundJoints", self.robot.constraints.bounds_joints),
-                    ("ContactFrames", self.robot.constraints.contact_frames),
-                    ("CollisionBodies", {
-                        name: constraint for constraints in (
-                            self.robot.constraints.collision_bodies)
-                        for name, constraint in constraints.items()}),
-                    ("User", self.robot.constraints.user)))
-            i = 0
-            while i < len(self.robot.log_constraint_fieldnames):
-                fieldname = self.robot.log_constraint_fieldnames[i]
-                for registry_type, registry in constraint_lookup_pairs:
-                    if fieldname.startswith(registry_type):
-                        break
-                constraint_name = fieldname[len(registry_type):-1]
-                constraint = registry[constraint_name]
-                self._constraint_lambda_list.append(constraint.lambda_c)
-                self._constraint_lambda_slices.append(
-                    self._constraint_lambda_all[i:(i + constraint.size)])
-                i += constraint.size
+                self._f_external_batch)
 
     def refresh(self) -> State:
         """Compute the current state depending on the mode of evaluation, and
@@ -1039,29 +1153,47 @@ class StateQuantity(InterfaceQuantity[State]):
         """
         # Update state at which the quantity must be evaluated
         if self.mode == QuantityEvalMode.TRUE:
+            # Update the current simulation time
             self.state.t = self.env.stepper_state.t
+
+            # Update external forces and constraint multipliers in state buffer
             multi_array_copyto(self._f_external_slices, self._f_external_list)
+            multi_array_copyto(
+                self._constraint_lambda_slices, self._constraint_lambda_list)
         else:
             self.state = self.trajectory.get()
 
         if self.mode == QuantityEvalMode.REFERENCE:
-            # Update all dynamical quantities that can be given available data
-            update_quantities(
-                self.robot,
-                self.state.q,
-                self.state.v,
-                self.state.a,
-                update_physics=True,
-                update_centroidal=True,
-                update_energy=True,
-                update_jacobian=False,
-                update_collisions=True,
-                use_theoretical_model=self.trajectory.use_theoretical_model)
+            # Copy body external forces from stacked buffer to force vector
+            has_forces = self.state.f_external is not None
+            if has_forces:
+                array_copyto(self._f_external_batch, self.state.f_external)
+                multi_array_copyto(self._f_external_list,
+                                   self._f_external_slices)
 
-            # Restore lagrangian multipliers of the constraints
-            array_copyto(self._constraint_lambda_all, self.state.lambda_c)
-            multi_array_copyto(
-                self._constraint_lambda_list, self._constraint_lambda_slices)
+            # Update all dynamical quantities that can be given available data
+            if self.update_kinematics:
+                update_quantities(
+                    self.robot,
+                    self.state.q,
+                    self.state.v,
+                    self.state.a,
+                    self._f_external_vec if has_forces else None,
+                    update_dynamics=self._update_dynamics,
+                    update_centroidal=self._update_centroidal,
+                    update_energy=self._update_energy,
+                    update_jacobian=self._update_jacobian,
+                    update_collisions=False,
+                    use_theoretical_model=(
+                        self.trajectory.use_theoretical_model))
+
+            # Restore lagrangian multipliers of the constraints if available
+            has_constraints = self.state.lambda_c is not None
+            if has_constraints:
+                array_copyto(
+                    self._constraint_lambda_batch, self.state.lambda_c)
+                multi_array_copyto(self._constraint_lambda_list,
+                                   self._constraint_lambda_slices)
 
         # Return state
         return self.state

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -904,7 +904,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[ObsT, ActT],
             if terminated or truncated:
                 self._num_steps_beyond_terminate = 0
         else:
-            if not self.is_training and self._num_steps_beyond_terminate == 0:
+            if self.is_training and self._num_steps_beyond_terminate == 0:
                 LOGGER.error(
                     "Calling `step` after termination causes the reward to be "
                     "'nan' systematically and is strongly discouraged in "

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/__init__.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/__init__.py
@@ -13,7 +13,7 @@ from .generic import (OrientationType,
                       MultiFramesPosition,
                       MultiFramesXYZQuat,
                       MultiFramesMeanXYZQuat,
-                      AverageFramePose,
+                      AverageFrameXYZQuat,
                       AverageFrameRollPitch,
                       AverageFrameSpatialVelocity,
                       ActuatedJointsPosition)
@@ -24,10 +24,10 @@ from .locomotion import (BaseOdometryPose,
                          AverageBaseMomentum,
                          MultiFootMeanXYZQuat,
                          MultiFootRelativeXYZQuat,
+                         MultiContactRelativeForceTangential,
                          CenterOfMass,
                          CapturePoint,
                          ZeroMomentPoint,
-                         MultiContactRelativeForceTangential,
                          translate_position_odom)
 
 
@@ -48,7 +48,8 @@ __all__ = [
     'MultiFootMeanXYZQuat',
     'MultiFootRelativeXYZQuat',
     'MultiFootMeanOdometryPose',
-    'AverageFramePose',
+    'MultiContactRelativeForceTangential',
+    'AverageFrameXYZQuat',
     'AverageFrameRollPitch',
     'AverageFrameSpatialVelocity',
     'AverageBaseSpatialVelocity',
@@ -59,6 +60,5 @@ __all__ = [
     'CenterOfMass',
     'CapturePoint',
     'ZeroMomentPoint',
-    'MultiContactRelativeForceTangential',
     'translate_position_odom'
 ]

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
@@ -1126,8 +1126,9 @@ class _DifferenceFrameXYZQuat(InterfaceQuantity[np.ndarray]):
 
 
 @dataclass(unsafe_hash=True)
-class AverageFramePose(InterfaceQuantity[np.ndarray]):
-    """Average pose of a given frame over the whole agent step.
+class AverageFrameXYZQuat(InterfaceQuantity[np.ndarray]):
+    """Spatial vector representation (X, Y, Z, QuatX, QuatY, QuatZ, QuatW) of
+    the average pose of a given frame over the whole agent step.
 
     The average frame pose is obtained by integration of the average velocity
     over the whole agent step, backward in time from the state at the end of
@@ -1203,7 +1204,7 @@ class AverageFrameRollPitch(InterfaceQuantity[np.ndarray]):
     Roll-Pitch_yaw decomposition of a given frame over the whole agent step.
 
     .. seealso::
-        See `remove_yaw_from_quat` and `AverageFramePose` for details about
+        See `remove_yaw_from_quat` and `AverageFrameXYZQuat` for details about
         the Roll-Pitch-Yaw decomposition and how the average frame pose is
         defined respectively.
     """
@@ -1245,7 +1246,7 @@ class AverageFrameRollPitch(InterfaceQuantity[np.ndarray]):
             parent,
             requirements=dict(
                 quat_mean=(MaskedQuantity, dict(
-                    quantity=(AverageFramePose, dict(
+                    quantity=(AverageFrameXYZQuat, dict(
                         frame_name=frame_name,
                         mode=mode)),
                     axis=0,
@@ -1340,7 +1341,7 @@ class AverageFrameSpatialVelocity(InterfaceQuantity[np.ndarray]):
                     frame_name=frame_name,
                     mode=mode)),
                 quat_mean=(MaskedQuantity, dict(
-                    quantity=(AverageFramePose, dict(
+                    quantity=(AverageFrameXYZQuat, dict(
                         frame_name=frame_name,
                         mode=mode)),
                     axis=0,

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/locomotion.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/locomotion.py
@@ -14,7 +14,8 @@ from jiminy_py.dynamics import update_quantities
 import pinocchio as pin
 
 from ..bases import (
-    InterfaceJiminyEnv, InterfaceQuantity, AbstractQuantity, QuantityEvalMode)
+    InterfaceJiminyEnv, InterfaceQuantity, AbstractQuantity, StateQuantity,
+    QuantityEvalMode)
 from ..utils import (
     matrix_to_yaw, quat_to_yaw, quat_to_matrix, quat_multiply, quat_apply)
 
@@ -660,7 +661,13 @@ class CenterOfMass(AbstractQuantity[np.ndarray]):
 
         # Call base implementation
         super().__init__(
-            env, parent, requirements={}, mode=mode, auto_refresh=False)
+            env,
+            parent,
+            requirements=dict(
+                state=(StateQuantity, dict(
+                    update_centroidal=True))),
+            mode=mode,
+            auto_refresh=False)
 
         # Pre-allocate memory for the CoM quantity
         self._com_data: np.ndarray = np.array([])
@@ -747,8 +754,7 @@ class ZeroMomentPoint(AbstractQuantity[np.ndarray]):
                 com_position=(CenterOfMass, dict(
                     kinematic_level=pin.POSITION,
                     mode=mode)),
-                odom_pose=(BaseOdometryPose, dict(mode=mode))
-            ),
+                odom_pose=(BaseOdometryPose, dict(mode=mode))),
             mode=mode,
             auto_refresh=False)
 
@@ -855,8 +861,7 @@ class CapturePoint(AbstractQuantity[np.ndarray]):
                 com_velocity=(CenterOfMass, dict(
                     kinematic_level=pin.VELOCITY,
                     mode=mode)),
-                odom_pose=(BaseOdometryPose, dict(mode=mode))
-            ),
+                odom_pose=(BaseOdometryPose, dict(mode=mode))),
             mode=mode,
             auto_refresh=False)
 
@@ -881,7 +886,7 @@ class CapturePoint(AbstractQuantity[np.ndarray]):
         update_quantities(
             self.robot,
             pin.neutral(self.robot.pinocchio_model_th),
-            update_physics=True,
+            update_dynamics=False,
             update_centroidal=True,
             update_energy=False,
             update_jacobian=False,
@@ -933,10 +938,7 @@ class MultiContactRelativeForceTangential(InterfaceQuantity[np.ndarray]):
         """
         # Call base implementation
         super().__init__(
-            env,
-            parent,
-            requirements={},
-            auto_refresh=False)
+            env, parent, requirements={}, auto_refresh=False)
 
         # Weight of the robot
         self._robot_weight: float = -1

--- a/python/gym_jiminy/common/gym_jiminy/common/wrappers/observation_stack.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/wrappers/observation_stack.py
@@ -198,7 +198,7 @@ class StackObservation(
             if (step_ratio // frame_ratio) * frame_ratio != step_ratio:
                 LOGGER.warning(
                     "Beware `step_dt // observe_dt` is not a multiple of "
-                    "`skip_frame_ratio + 1`.")
+                    "`skip_frames_ratio + 1`.")
 
         # Copy observe and control update periods from wrapped environment
         self.observe_dt = self.env.observe_dt

--- a/python/gym_jiminy/unit_py/data/anymal_pipeline.json
+++ b/python/gym_jiminy/unit_py/data/anymal_pipeline.json
@@ -58,8 +58,8 @@
             ["measurements", "ImuSensor"],
             ["actions"]
           ],
-          "num_stack": 3,
-          "skip_frames_ratio": 2
+          "num_stack": 4,
+          "skip_frames_ratio": 3
         }
       }
     }

--- a/python/gym_jiminy/unit_py/data/anymal_pipeline.toml
+++ b/python/gym_jiminy/unit_py/data/anymal_pipeline.toml
@@ -54,5 +54,5 @@ nested_filter_keys = [
   ["measurements", "ImuSensor"],
   ["actions"],
 ]
-num_stack = 3
-skip_frames_ratio = 2
+num_stack = 4
+skip_frames_ratio = 3

--- a/python/gym_jiminy/unit_py/test_misc.py
+++ b/python/gym_jiminy/unit_py/test_misc.py
@@ -29,7 +29,8 @@ class Miscellaneous(unittest.TestCase):
         """ TODO: Write documentation.
         """
         # Instantiate the environment
-        env = gym.make("gym_jiminy.envs:atlas", debug=True)
+        env = gym.make("gym_jiminy.envs:atlas", debug=False)
+        env.eval()
 
         # Run a few steps
         env.reset(seed=0)
@@ -50,7 +51,8 @@ class Miscellaneous(unittest.TestCase):
                                     backend="panda3d-sync",
                                     record_video_path=video_path,
                                     display_contacts=True,
-                                    display_f_external=True)
+                                    display_f_external=True,
+                                    verbose=False)
         Viewer.close()
 
         # Check the external forces has been updated

--- a/python/gym_jiminy/unit_py/test_quantities.py
+++ b/python/gym_jiminy/unit_py/test_quantities.py
@@ -262,7 +262,7 @@ class Quantities(unittest.TestCase):
             env.quantities["v_masked"], quantity.data[[0, 2, 4]])
 
     def test_true_vs_reference(self):
-        env = gym.make("gym_jiminy.envs:atlas")
+        env = gym.make("gym_jiminy.envs:atlas", debug=True)
 
         frame_names = [
             frame.name for frame in env.robot.pinocchio_model.frames]

--- a/python/gym_jiminy/unit_py/test_quantities.py
+++ b/python/gym_jiminy/unit_py/test_quantities.py
@@ -309,8 +309,10 @@ class Quantities(unittest.TestCase):
             env.quantities["ref"] = quantity_creator(
                 QuantityEvalMode.REFERENCE)
 
+            # No trajectory has been selected
             with self.assertRaises(RuntimeError):
                 env.reset(seed=0)
+                env.quantities["ref"]
 
             env.quantities.add_trajectory("reference", trajectory)
             env.quantities.select_trajectory("reference")

--- a/python/gym_jiminy/unit_py/test_quantities.py
+++ b/python/gym_jiminy/unit_py/test_quantities.py
@@ -262,7 +262,8 @@ class Quantities(unittest.TestCase):
             env.quantities["v_masked"], quantity.data[[0, 2, 4]])
 
     def test_true_vs_reference(self):
-        env = gym.make("gym_jiminy.envs:atlas", debug=True)
+        env = gym.make("gym_jiminy.envs:atlas", debug=False)
+        env.eval()
 
         frame_names = [
             frame.name for frame in env.robot.pinocchio_model.frames]
@@ -409,7 +410,7 @@ class Quantities(unittest.TestCase):
         update_quantities(
             env.robot,
             pin.neutral(env.robot.pinocchio_model_th),
-            update_physics=True,
+            update_dynamics=True,
             update_centroidal=True,
             update_energy=False,
             update_jacobian=False,

--- a/python/gym_jiminy/unit_py/test_rewards.py
+++ b/python/gym_jiminy/unit_py/test_rewards.py
@@ -28,15 +28,17 @@ class Rewards(unittest.TestCase):
     """ TODO: Write documentation
     """
     def setUp(self):
-        env = gym.make("gym_jiminy.envs:atlas", debug=True)
-        env.reset(seed=1)
-        action = env.action_space.sample()
-        for _ in range(10):
-            env.step(action)
-        env.stop()
-        trajectory = extract_trajectory_from_log(env.log_data)
+        self.env = gym.make("gym_jiminy.envs:atlas-pid", debug=False)
 
-        self.env = gym.make("gym_jiminy.envs:atlas")
+        self.env.eval()
+        self.env.reset(seed=1)
+        action = self.env.action_space.sample()
+        for _ in range(10):
+            self.env.step(action)
+        self.env.stop()
+        trajectory = extract_trajectory_from_log(self.env.log_data)
+        self.env.train()
+
         self.env.quantities.add_trajectory("reference", trajectory)
         self.env.quantities.select_trajectory("reference")
 
@@ -130,12 +132,11 @@ class Rewards(unittest.TestCase):
 
     def test_friction(self):
         CUTOFF = 0.5
-        env = gym.make("gym_jiminy.envs:atlas-pid", debug=True)
-        reward_friction = MinimizeFrictionReward(env, cutoff=CUTOFF)
+        reward_friction = MinimizeFrictionReward(self.env, cutoff=CUTOFF)
         quantity = reward_friction.quantity
 
-        env.reset(seed=0)
-        _, _, terminated, _, _ = env.step(env.action)
+        self.env.reset(seed=0)
+        _, _, terminated, _, _ = self.env.step(self.env.action)
         force_tangential_rel = quantity.get()
         force_tangential_rel_norm = np.sum(np.square(force_tangential_rel))
 

--- a/python/gym_jiminy/unit_py/test_rewards.py
+++ b/python/gym_jiminy/unit_py/test_rewards.py
@@ -28,15 +28,15 @@ class Rewards(unittest.TestCase):
     """ TODO: Write documentation
     """
     def setUp(self):
-        self.env = gym.make("gym_jiminy.envs:atlas")
-
-        self.env.reset(seed=1)
-        action = self.env.action_space.sample()
+        env = gym.make("gym_jiminy.envs:atlas", debug=True)
+        env.reset(seed=1)
+        action = env.action_space.sample()
         for _ in range(10):
-            self.env.step(action)
-        self.env.stop()
+            env.step(action)
+        env.stop()
+        trajectory = extract_trajectory_from_log(env.log_data)
 
-        trajectory = extract_trajectory_from_log(self.env.log_data)
+        self.env = gym.make("gym_jiminy.envs:atlas")
         self.env.quantities.add_trajectory("reference", trajectory)
         self.env.quantities.select_trajectory("reference")
 

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -54,13 +54,9 @@ def extract_variables_from_log(log_vars: Dict[str, np.ndarray],
     :param fieldnames: Structured fieldnames.
     :param namespace: Namespace of the fieldnames. Empty string to disable.
                       Optional: Empty by default.
-    :param keep_structure: Whether to return a dictionary mapping flattened
-                           fieldnames to values.
-                           Optional: True by default.
-
-    :returns:
-        `np.ndarray` or None for each fieldname individually depending if it is
-        found or not.
+    :param as_dict: Whether to return a dictionary mapping flattened fieldnames
+                    to values.
+                    Optional: True by default.
     """
     # Extract values from log if it exists
     if as_dict:
@@ -238,7 +234,8 @@ def extract_trajectory_from_log(log_data: Dict[str, Any],
                  "acceleration",
                  "effort",
                  "command",
-                 "f_external"):
+                 "f_external",
+                 "constraint"):
         fieldnames = getattr(robot, f"log_{name}_fieldnames")
         try:
             data[name] = extract_variables_from_log(

--- a/python/jiminy_py/unit_py/test_simple_pendulum.py
+++ b/python/jiminy_py/unit_py/test_simple_pendulum.py
@@ -230,7 +230,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         assert np.abs(state_0.t) < 1e-12
         assert np.abs(state_f.t - T_END) < 1e-12
         for key, value in asdict(state_f).items():
-            if key == "t":
+            if key in ("t", "lambda_c"):
                 continue
             data = getattr(robot_state, key)
             if key == "f_external":

--- a/python/jiminy_py/unit_py/utilities.py
+++ b/python/jiminy_py/unit_py/utilities.py
@@ -119,6 +119,7 @@ def setup_controller_and_engine(
     telemetry_options["enableEffort"] = True
     telemetry_options["enableCommand"] = True
     telemetry_options["enableForceExternal"] = True
+    telemetry_options["enableConstraint"] = True
     telemetry_options["enableEnergy"] = True
     engine.set_options(engine_options)
 

--- a/python/jiminy_pywrap/src/constraints.cc
+++ b/python/jiminy_pywrap/src/constraints.cc
@@ -104,6 +104,7 @@ namespace jiminy::python
             .ADD_PROPERTY_GET_WITH_POLICY("type",
                                           &AbstractConstraintBase::getType,
                                           bp::return_value_policy<bp::return_by_value>())
+            .ADD_PROPERTY_GET("size", &AbstractConstraintBase::getSize)
             .ADD_PROPERTY_GET_SET("is_enabled",
                                   &AbstractConstraintBase::getIsEnabled,
                                   &internal::constraints::setIsEnable)
@@ -283,14 +284,14 @@ namespace jiminy::python
             return constraintCollisionBodies;
         }
 
-        static bp::dict getRegistry(ConstraintTree & self)
+        static bp::dict getUser(ConstraintTree & self)
         {
-            bp::dict constraintRegistryPy;
-            for (auto & [name, constraint] : self.registry)
+            bp::dict constraintUserPy;
+            for (auto & [name, constraint] : self.user)
             {
-                constraintRegistryPy[name] = constraint;
+                constraintUserPy[name] = constraint;
             }
-            return constraintRegistryPy;
+            return constraintUserPy;
         }
     }
 
@@ -301,6 +302,6 @@ namespace jiminy::python
             .ADD_PROPERTY_GET("bounds_joints", &internal::constraint_tree::getBoundJoints)
             .ADD_PROPERTY_GET("contact_frames", &internal::constraint_tree::getContactFrames)
             .ADD_PROPERTY_GET("collision_bodies", &internal::constraint_tree::getCollisionBodies)
-            .ADD_PROPERTY_GET("registry", &internal::constraint_tree::getRegistry);
+            .ADD_PROPERTY_GET("user", &internal::constraint_tree::getUser);
     }
 }

--- a/python/jiminy_pywrap/src/helpers.cc
+++ b/python/jiminy_pywrap/src/helpers.cc
@@ -321,80 +321,113 @@ namespace jiminy::python
 
     void exposeHelpers()
     {
-        // clang-format off
-        bp::def("build_geom_from_urdf", &buildGeometryModelFromUrdf,
-                                        (bp::arg("pinocchio_model"), "urdf_filename", "geom_type",
-                                         bp::arg("mesh_package_dirs") = bp::list(),
-                                         bp::arg("load_meshes") = true,
-                                         bp::arg("make_meshes_convex") = false));
+        bp::def("build_geom_from_urdf",
+                &buildGeometryModelFromUrdf,
+                (bp::arg("pinocchio_model"),
+                 "urdf_filename",
+                 "geom_type",
+                 bp::arg("mesh_package_dirs") = bp::list(),
+                 bp::arg("load_meshes") = true,
+                 bp::arg("make_meshes_convex") = false));
 
-        bp::def("build_models_from_urdf", &buildMultipleModelsFromUrdf,
-                                          (bp::arg("urdf_path"), "has_freeflyer",
-                                           bp::arg("mesh_package_dirs") = bp::list(),
-                                           bp::arg("build_visual_model") = false,
-                                           bp::arg("load_visual_meshes") = false));
+        bp::def("build_models_from_urdf",
+                &buildMultipleModelsFromUrdf,
+                (bp::arg("urdf_path"),
+                 "has_freeflyer",
+                 bp::arg("mesh_package_dirs") = bp::list(),
+                 bp::arg("build_visual_model") = false,
+                 bp::arg("load_visual_meshes") = false));
 
         bp::def("save_to_binary", &saveRobotToBinary, (bp::arg("robot")));
 
-        bp::def("load_from_binary", &buildRobotFromBinary,
-                                    (bp::arg("data"),
-                                     bp::arg("mesh_path_dir") = bp::object(),
-                                     bp::arg("mesh_package_dirs") = bp::list()));
+        bp::def("load_from_binary",
+                &buildRobotFromBinary,
+                (bp::arg("data"),
+                 bp::arg("mesh_path_dir") = bp::object(),
+                 bp::arg("mesh_package_dirs") = bp::list()));
 
         bp::def("get_joint_type", &getJointType, bp::arg("joint_model"));
-        bp::def("get_joint_type", &getJointTypeFromIndex,
-                                  (bp::arg("pinocchio_model"), "joint_index"));
-        bp::def("get_joint_indices", &getJointIndices,
-                                     (bp::arg("pinocchio_model"), "joint_names"));
-        bp::def("get_joint_position_first_index", &getJointPositionFirstIndex,
-                                          (bp::arg("pinocchio_model"), "joint_name"));
-        bp::def("is_position_valid", &isPositionValid,
-                                     (bp::arg("pinocchio_model"), "position",
-                                      bp::arg("tol_abs") = std::numeric_limits<float>::epsilon()));
+        bp::def(
+            "get_joint_type", &getJointTypeFromIndex, (bp::arg("pinocchio_model"), "joint_index"));
+        bp::def(
+            "get_joint_indices", &getJointIndices, (bp::arg("pinocchio_model"), "joint_names"));
+        bp::def("get_joint_position_first_index",
+                &getJointPositionFirstIndex,
+                (bp::arg("pinocchio_model"), "joint_name"));
+        bp::def("is_position_valid",
+                &isPositionValid,
+                (bp::arg("pinocchio_model"),
+                 "position",
+                 bp::arg("tol_abs") = std::numeric_limits<float>::epsilon()));
 
-        bp::def("get_frame_indices", &getFrameIndices,
-                                     bp::return_value_policy<result_converter<true>>(),
-                                     (bp::arg("pinocchio_model"), "frame_names"));
-        bp::def("get_joint_indices", &getFrameIndices,
-                                     bp::return_value_policy<result_converter<true>>(),
-                                     (bp::arg("pinocchio_model"), "joint_names"));
+        bp::def("get_frame_indices",
+                &getFrameIndices,
+                bp::return_value_policy<result_converter<true>>(),
+                (bp::arg("pinocchio_model"), "frame_names"));
+        bp::def("get_joint_indices",
+                &getFrameIndices,
+                bp::return_value_policy<result_converter<true>>(),
+                (bp::arg("pinocchio_model"), "joint_names"));
 
         bp::def("array_copyto", &arrayCopyTo, (bp::arg("dst"), "src"));
         bp::def("multi_array_copyto", &multiArrayCopyTo, (bp::arg("dst"), "src"));
 
-        // Do not use EigenPy To-Python converter because it considers matrices with 1 column as vectors
-        bp::def("interpolate_positions", &interpolatePositions,
-                                         bp::return_value_policy<result_converter<true>>(),
-                                         (bp::arg("pinocchio_model"), "times_in", "positions_in", "times_out"));
+        // Do NOT use EigenPy to-python converter as it considers arrays with 1 column as vectors
+        bp::def("interpolate_positions",
+                &interpolatePositions,
+                bp::return_value_policy<result_converter<true>>(),
+                (bp::arg("pinocchio_model"), "times_in", "positions_in", "times_out"));
 
         bp::def("aba",
-                &pinocchio_overload::aba<
-                    double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd, pinocchio::Force>,
+                &pinocchio_overload::aba<double,
+                                         0,
+                                         pinocchio::JointCollectionDefaultTpl,
+                                         Eigen::VectorXd,
+                                         Eigen::VectorXd,
+                                         Eigen::VectorXd,
+                                         pinocchio::Force>,
                 bp::return_value_policy<result_converter<false>>(),
                 (bp::arg("pinocchio_model"), "pinocchio_data", "q", "v", "u", "fext"),
                 "Compute ABA with external forces, store the result in Data::ddq and return it.");
+        bp::def(
+            "rnea",
+            &pinocchio_overload::rnea<double,
+                                      0,
+                                      pinocchio::JointCollectionDefaultTpl,
+                                      Eigen::VectorXd,
+                                      Eigen::VectorXd,
+                                      Eigen::VectorXd>,
+            bp::return_value_policy<result_converter<false>>(),
+            (bp::arg("pinocchio_model"), "pinocchio_data", "q", "v", "a"),
+            "Compute the RNEA without external forces, store the result in Data and return it.");
         bp::def("rnea",
-                &pinocchio_overload::rnea<
-                    double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd>,
-                bp::return_value_policy<result_converter<false>>(),
-                (bp::arg("pinocchio_model"), "pinocchio_data", "q", "v", "a"),
-                "Compute the RNEA without external forces, store the result in Data and return it.");
-        bp::def("rnea",
-                &pinocchio_overload::rnea<
-                    double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd, Eigen::VectorXd, Eigen::VectorXd, pinocchio::Force>,
+                &pinocchio_overload::rnea<double,
+                                          0,
+                                          pinocchio::JointCollectionDefaultTpl,
+                                          Eigen::VectorXd,
+                                          Eigen::VectorXd,
+                                          Eigen::VectorXd,
+                                          pinocchio::Force>,
                 bp::return_value_policy<result_converter<false>>(),
                 (bp::arg("pinocchio_model"), "pinocchio_data", "q", "v", "a", "fext"),
                 "Compute the RNEA with external forces, store the result in Data and return it.");
         bp::def("crba",
-                &pinocchio_overload::crba<
-                    double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd>,
+                &pinocchio_overload::
+                    crba<double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd>,
                 bp::return_value_policy<result_converter<false>>(),
-                (bp::arg("pinocchio_model"), "pinocchio_data", "q", bp::arg("fast_math") = false),
+                (bp::arg("pinocchio_model"), "pinocchio_data", "q", bp::arg("fastmath") = false),
                 "Computes CRBA, store the result in Data and return it.");
         bp::def("computeKineticEnergy",
-                &pinocchio_overload::computeKineticEnergy<
-                    double, 0, pinocchio::JointCollectionDefaultTpl, Eigen::VectorXd, Eigen::VectorXd>,
-                (bp::arg("pinocchio_model"), "pinocchio_data", "q", "v"),
+                &pinocchio_overload::computeKineticEnergy<double,
+                                                          0,
+                                                          pinocchio::JointCollectionDefaultTpl,
+                                                          Eigen::VectorXd,
+                                                          Eigen::VectorXd>,
+                (bp::arg("pinocchio_model"),
+                 "pinocchio_data",
+                 "q",
+                 "v",
+                 bp::arg("update_kinematics") = true),
                 "Computes the forward kinematics and the kinematic energy of the model for the "
                 "given joint configuration and velocity given as input. "
                 "The result is accessible through data.kinetic_energy.");
@@ -402,9 +435,12 @@ namespace jiminy::python
         bp::def("computeJMinvJt",
                 &pinocchio_overload::computeJMinvJt<Eigen::MatrixXd>,
                 bp::return_value_policy<result_converter<false>>(),
-                (bp::arg("pinocchio_model"), "pinocchio_data", "J", bp::arg("update_decomposition") = true));
-        bp::def("solveJMinvJtv", &solveJMinvJtv,
+                (bp::arg("pinocchio_model"),
+                 "pinocchio_data",
+                 "J",
+                 bp::arg("update_decomposition") = true));
+        bp::def("solveJMinvJtv",
+                &solveJMinvJtv,
                 (bp::arg("pinocchio_data"), "v", bp::arg("update_decomposition") = true));
-        // clang-format on
     }
 }

--- a/python/jiminy_pywrap/src/robot.cc
+++ b/python/jiminy_pywrap/src/robot.cc
@@ -333,6 +333,9 @@ namespace jiminy::python
                                           bp::return_value_policy<result_converter<true>>())
             .ADD_PROPERTY_GET_WITH_POLICY("log_f_external_fieldnames",
                                           &Model::getLogForceExternalFieldnames,
+                                          bp::return_value_policy<result_converter<true>>())
+            .ADD_PROPERTY_GET_WITH_POLICY("log_constraint_fieldnames",
+                                          &Model::getLogConstraintFieldnames,
                                           bp::return_value_policy<result_converter<true>>());
     }
 

--- a/python/jiminy_pywrap/src/robot.cc
+++ b/python/jiminy_pywrap/src/robot.cc
@@ -98,30 +98,30 @@ namespace jiminy::python
             ConstraintTree constraints = self.getConstraints();
             constraints.foreach(
                 [&constraintsRows](const std::shared_ptr<AbstractConstraintBase> & constraint,
-                                   ConstraintNodeType /* node */)
+                                   ConstraintRegistryType /* type */)
                 {
                     if (!constraint->getIsEnabled())
                     {
                         return;
                     }
-                    constraintsRows += static_cast<Eigen::Index>(constraint->getDim());
+                    constraintsRows += static_cast<Eigen::Index>(constraint->getSize());
                 });
             Eigen::MatrixXd J(constraintsRows, self.nv());
             Eigen::VectorXd gamma(constraintsRows);
             constraints.foreach(
                 [&J, &gamma, &constraintRow](
                     const std::shared_ptr<AbstractConstraintBase> & constraint,
-                    ConstraintNodeType /* node */)
+                    ConstraintRegistryType /* type */)
                 {
                     if (!constraint->getIsEnabled())
                     {
                         return;
                     }
-                    const Eigen::Index constraintDim =
-                        static_cast<Eigen::Index>(constraint->getDim());
-                    J.middleRows(constraintRow, constraintDim) = constraint->getJacobian();
-                    gamma.segment(constraintRow, constraintDim) = constraint->getDrift();
-                    constraintRow += constraintDim;
+                    const Eigen::Index constraintSize =
+                        static_cast<Eigen::Index>(constraint->getSize());
+                    J.middleRows(constraintRow, constraintSize) = constraint->getJacobian();
+                    gamma.segment(constraintRow, constraintSize) = constraint->getDrift();
+                    constraintRow += constraintSize;
                 });
             return bp::make_tuple(J, gamma);
         }
@@ -221,11 +221,6 @@ namespace jiminy::python
             .def("remove_constraint",
                  static_cast<void (Model::*)(const std::string &)>(&Model::removeConstraint),
                  (bp::arg("self"), "name"))
-            .def("get_constraint",
-                 static_cast<std::shared_ptr<AbstractConstraintBase> (Model::*)(
-                     const std::string &)>(&Model::getConstraint),
-                 (bp::arg("self"), "constraint_name"))
-            .def("exist_constraint", &Model::existConstraint, (bp::arg("self"), "constraint_name"))
             .ADD_PROPERTY_GET("has_constraints", &Model::hasConstraints)
             .ADD_PROPERTY_GET_WITH_POLICY("constraints",
                                           &Model::getConstraints,


### PR DESCRIPTION
* [core] Add option to log constraint lambda multipliers.
* [core] Replace constraint tree node terminolgy for registry for clarity. 
* [core] Enforce unique constraint name per registry not globally, then remove now irrelevant helpers.
* [core] Make sure no constraint is added/removed if simulation is running.
* [python|gym] Add contraint lambda multipliers to state and extracted trajectory.
* [python/dynamics] Fix trajectory interpolation preferring t+ over t-.
* [gym/common] Refresh state quantities only if needed.