### PR TITLE
 [jiminy_py] Fix 'tree.unflatten_as' mixing up key order for 'gym.spaces.Dict'.

### DIFF
--- a/python/jiminy_py/src/jiminy_py/tree.py
+++ b/python/jiminy_py/src/jiminy_py/tree.py
@@ -176,8 +176,9 @@ def _unflatten_as(data: StructNested[Any],
         flat_items = [(key, _unflatten_as(value, data_leaf_it))
             for key, value in data.items()]  # type: ignore[union-attr]
         try:
-            # Initialisation from dict cannot be the default path as `gym.spaces.Dict`
-            # would sort keys in this specific scenario, which must be avoided.
+            # Initialisation from dict cannot be the default path as
+            # `gym.spaces.Dict` would sort keys in this specific scenario,
+            # which must be avoided.
             return data_type(flat_items)  # type: ignore[call-arg]
         except (ValueError, RuntimeError):
             # Fallback to initialisation from dict in the rare event of

--- a/python/jiminy_py/src/jiminy_py/tree.py
+++ b/python/jiminy_py/src/jiminy_py/tree.py
@@ -173,19 +173,15 @@ def _unflatten_as(data: StructNested[Any],
     """
     data_type = type(data)
     if issubclass_mapping(data_type):  # type: ignore[arg-type]
+        flat_items = [(key, _unflatten_as(value, data_leaf_it))
+            for key, value in data.items()]  # type: ignore[union-attr]
         try:
-            return data_type([  # type: ignore[call-arg]
-                (key, _unflatten_as(value, data_leaf_it))
-                for key, value in data.items()  # type: ignore[union-attr]
-            ])
+            return data_type(flat_items)  # type: ignore[call-arg]
         except (ValueError, RuntimeError):
             # Fallback to initialisation from dict in the rare event of
             # a container type not supporting initialisation from a
             # sequence of key-value pairs.
-            return data_type({  # type: ignore[call-arg]
-                key: _unflatten_as(value, data_leaf_it)
-                for key, value in data.items()  # type: ignore[union-attr]
-            })
+            return data_type(dict(flat_items))  # type: ignore[call-arg]
     if issubclass_sequence(data_type):  # type: ignore[arg-type]
         return data_type(tuple(  # type: ignore[call-arg]
             _unflatten_as(value, data_leaf_it) for value in data

--- a/python/jiminy_py/src/jiminy_py/tree.py
+++ b/python/jiminy_py/src/jiminy_py/tree.py
@@ -19,6 +19,7 @@ of use and versatility rather with optimal performance.
 from functools import lru_cache
 from itertools import chain, starmap
 from collections.abc import (Mapping, ValuesView, Sequence, Set)
+from collections import OrderedDict
 from typing import (
     Any, Union, Mapping as MappingT, Iterable, Iterator as Iterator, Tuple,
     TypeVar, Callable, Type)
@@ -173,10 +174,10 @@ def _unflatten_as(data: StructNested[Any],
     """
     data_type = type(data)
     if issubclass_mapping(data_type):  # type: ignore[arg-type]
-        return data_type({  # type: ignore[call-arg]
+        return data_type(OrderedDict({  # type: ignore[call-arg]
             key: _unflatten_as(value, data_leaf_it)
             for key, value in data.items()  # type: ignore[union-attr]
-        })
+        }))
     if issubclass_sequence(data_type):  # type: ignore[arg-type]
         return data_type(tuple(  # type: ignore[call-arg]
             _unflatten_as(value, data_leaf_it) for value in data

--- a/python/jiminy_py/src/jiminy_py/tree.py
+++ b/python/jiminy_py/src/jiminy_py/tree.py
@@ -173,8 +173,10 @@ def _unflatten_as(data: StructNested[Any],
     """
     data_type = type(data)
     if issubclass_mapping(data_type):  # type: ignore[arg-type]
-        flat_items = [(key, _unflatten_as(value, data_leaf_it))
-            for key, value in data.items()]  # type: ignore[union-attr]
+        flat_items = [
+            (key, _unflatten_as(value, data_leaf_it))
+            for key, value in data.items()  # type: ignore[union-attr]
+        ]
         try:
             # Initialisation from dict cannot be the default path as
             # `gym.spaces.Dict` would sort keys in this specific scenario,

--- a/python/jiminy_py/src/jiminy_py/tree.py
+++ b/python/jiminy_py/src/jiminy_py/tree.py
@@ -176,6 +176,8 @@ def _unflatten_as(data: StructNested[Any],
         flat_items = [(key, _unflatten_as(value, data_leaf_it))
             for key, value in data.items()]  # type: ignore[union-attr]
         try:
+            # Initialisation from dict cannot be the default path as `gym.spaces.Dict`
+            # would sort keys in this specific scenario, which must be avoided.
             return data_type(flat_items)  # type: ignore[call-arg]
         except (ValueError, RuntimeError):
             # Fallback to initialisation from dict in the rare event of


### PR DESCRIPTION
Resolves #818 