### PR TITLE
[core] Faster ground profile querying.

### DIFF
--- a/core/include/jiminy/core/engine/engine.h
+++ b/core/include/jiminy/core/engine/engine.h
@@ -292,10 +292,13 @@ namespace jiminy
             config["groundProfile"] = HeightmapFunction(
                 [](const Eigen::Vector2d & /* xy */,
                    double & height,
-                   Eigen::Ref<Eigen::Vector3d> normal) -> void
+                   std::optional<Eigen::Ref<Eigen::Vector3d>> normal) -> void
                 {
                     height = 0.0;
-                    normal = Eigen::Vector3d::UnitZ();
+                    if (normal.has_value())
+                    {
+                        normal->setUnit(2);
+                    }
                 });
 
             return config;

--- a/core/include/jiminy/core/engine/engine.h
+++ b/core/include/jiminy/core/engine/engine.h
@@ -297,7 +297,7 @@ namespace jiminy
                     height = 0.0;
                     if (normal.has_value())
                     {
-                        normal->setUnit(2);
+                        normal.value() = Eigen::Vector3d::UnitZ();
                     }
                 });
 

--- a/core/include/jiminy/core/fwd.h
+++ b/core/include/jiminy/core/fwd.h
@@ -1,20 +1,20 @@
 #ifndef JIMINY_FORWARD_H
 #define JIMINY_FORWARD_H
 
-#include <string_view>    // `std::string_view`
 #include <cstdint>        // `int32_t`, `int64_t`, `uint32_t`, `uint64_t`, ...
-#include <functional>     // `std::function`, `std::invoke`
-#include <limits>         // `std::numeric_limits`
 #include <map>            // `std::map`
+#include <unordered_map>  // `std::unordered_map`
 #include <deque>          // `std::deque`
+#include <vector>         // `std::vector`
+#include <utility>        // `std::pair`
+#include <optional>       // `std::optional`
 #include <string>         // `std::string`
 #include <sstream>        // `std::ostringstream`
-#include <unordered_map>  // `std::unordered_map`
-#include <utility>        // `std::pair`
-#include <vector>         // `std::vector`
+#include <functional>     // `std::function`, `std::invoke`
+#include <limits>         // `std::numeric_limits`
 #include <memory>         // `std::addressof`
 #include <utility>        // `std::forward`
-#include <stdexcept>      // `std::runtime_error`, `std::logic_error`
+#include <stdexcept>      // `std::logic_error`
 #include <type_traits>  // `std::enable_if_t`, `std::decay_t`, `std::add_pointer_t`, `std::is_same_v`, ...
 
 #include "pinocchio/fwd.hpp"            // To avoid having to include it everywhere
@@ -196,9 +196,10 @@ namespace jiminy
 
     // Ground profile functors.
     // FIXME: use `std::move_only_function` instead of `std::function` when moving to C++23
-    using HeightmapFunction = std::function<void(const Eigen::Vector2d & /* xy */,
-                                                 double & /* height */,
-                                                 Eigen::Ref<Eigen::Vector3d> /* normal */)>;
+    using HeightmapFunction =
+        std::function<void(const Eigen::Vector2d & /* xy */,
+                           double & /* height */,
+                           std::optional<Eigen::Ref<Eigen::Vector3d>> /* normal */)>;
 
     // Flexible joints
     struct FlexibilityJointConfig

--- a/core/include/jiminy/core/utilities/random.h
+++ b/core/include/jiminy/core/utilities/random.h
@@ -410,7 +410,19 @@ namespace jiminy
 
     // ****************************** Continuous Perlin processes ****************************** //
 
+    /// \brief Non-cryptographic hash function initially designed for hash-based lookup.
+    ///
+    /// \sa Murmursh algorithms were proposed by Austin Appleby and placed in public domain.
+    ///     The author hereby disclaims copyright to this source code:
+    ///     https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
     uint32_t MurmurHash3(const void * key, int32_t len, uint32_t seed) noexcept;
+
+    /// \brief Non-cryptographic hash function initially designed for hash-based lookup.
+    ///
+    /// \sa xxHash algorithms were proposed by Yann Collet and placed in the public domain.
+    ///     The author hereby disclaims copyright to this source code:
+    ///     https://github.com/Cyan4973/xxHash/blob/dev/xxhash.h
+    uint32_t xxHash(const void * key, int32_t len, uint32_t seed) noexcept;
 
     template<template<unsigned int> class DerivedPerlinNoiseOctave, unsigned int N>
     class JIMINY_TEMPLATE_DLLAPI AbstractPerlinNoiseOctave

--- a/core/include/jiminy/core/utilities/random.hxx
+++ b/core/include/jiminy/core/utilities/random.hxx
@@ -204,7 +204,7 @@ namespace jiminy
 
     static inline double derivativeFade(double delta) noexcept
     {
-        return 30 * delta * delta * (delta * (delta - 2.0) + 1.0);
+        return 30.0 * delta * delta * (delta * (delta - 2.0) + 1.0);
     }
 
     template<typename T1, typename T2>
@@ -419,7 +419,7 @@ namespace jiminy
         constexpr float fHashMax = static_cast<float>(std::numeric_limits<uint32_t>::max());
 
         // Compute knot hash
-        uint32_t hash = MurmurHash3(knot.data(), static_cast<int32_t>(sizeof(int32_t) * N), seed_);
+        uint32_t hash = xxHash(knot.data(), static_cast<int32_t>(sizeof(int32_t) * N), seed_);
 
         /* Generate random gradient uniformly distributed on n-ball.
            For technical reference, see:
@@ -437,17 +437,17 @@ namespace jiminy
         {
             // Sample random vector on a 2-ball (disk) using
             // const double theta = 2 * M_PI * static_cast<float>(hash) / fHashMax;
-            // hash = MurmurHash3(&hash, sizeof(uint32_t), seed_);
+            // hash = xxHash(&hash, sizeof(uint32_t), seed_);
             // const float radius = std::sqrt(static_cast<float>(hash) / fHashMax);
             // return VectorN<double>{radius * std::cos(theta), radius * std::sin(theta)};
 
             /* The rejection method is much fast in 2d because it does not involve complex math
                (sqrt, sincos) and the acceptance rate is high (~78%) compared to the cost of
-               sampling random numbers using `MurmurHash3`. */
+               sampling random numbers using `xxHash`. */
             while (true)
             {
                 const float x = 2 * static_cast<float>(hash) / fHashMax - 1.0F;
-                hash = MurmurHash3(&hash, sizeof(uint32_t), seed_);
+                hash = xxHash(&hash, sizeof(uint32_t), seed_);
                 const float y = 2 * static_cast<float>(hash) / fHashMax - 1.0F;
                 if (x * x + y * y <= 1.0F)
                 {
@@ -463,9 +463,9 @@ namespace jiminy
             {
                 // Generate 2 uniformly distributed random variables
                 const float u1 = static_cast<float>(hash) / fHashMax;
-                hash = MurmurHash3(&hash, sizeof(uint32_t), seed_);
+                hash = xxHash(&hash, sizeof(uint32_t), seed_);
                 const float u2 = static_cast<float>(hash) / fHashMax;
-                hash = MurmurHash3(&hash, sizeof(uint32_t), seed_);
+                hash = xxHash(&hash, sizeof(uint32_t), seed_);
 
                 // Apply Box-Mueller algorithm to deduce 2 normally distributed random variables
                 const double theta = 2 * M_PI * u2;

--- a/core/src/io/serialization.cc
+++ b/core/src/io/serialization.cc
@@ -250,10 +250,13 @@ namespace boost::serialization
     {
         fun = [](const Eigen::Vector2d & /* xy */,
                  double & height,
-                 Eigen::Ref<Eigen::Vector3d> normal)
+                 std::optional<Eigen::Ref<Eigen::Vector3d>> normal)
         {
             height = 0.0;
-            normal = Eigen::Vector3d::UnitZ();
+            if (normal.has_value())
+            {
+                normal.value() = Eigen::Vector3d::UnitZ();
+            }
         };
     }
 

--- a/core/src/utilities/json.cc
+++ b/core/src/utilities/json.cc
@@ -147,10 +147,13 @@ namespace jiminy
     {
         return {[](const Eigen::Vector2d & /* xy */,
                    double & height,
-                   Eigen::Ref<Eigen::Vector3d> normal) -> void
+                   std::optional<Eigen::Ref<Eigen::Vector3d>> normal) -> void
                 {
                     height = 0.0;
-                    normal = Eigen::Vector3d::UnitZ();
+                    if (normal.has_value())
+                    {
+                        normal.value() = Eigen::Vector3d::UnitZ();
+                    }
                 }};
     }
 

--- a/core/src/utilities/random.cc
+++ b/core/src/utilities/random.cc
@@ -168,17 +168,87 @@ namespace jiminy
 
     // **************************** Non-cryptographic hash function **************************** //
 
-    static uint32_t rotl32(uint32_t x, int8_t r) noexcept
+#if !defined(NO_CLANG_BUILTIN) && __has_builtin(__builtin_rotateleft32)
+#    define rotl32 __builtin_rotateleft32
+/* Note: although _rotl exists for minGW (GCC under windows), performance seems poor */
+#elif defined(_MSC_VER)
+#    define rotl32(x, r) _rotl(x, r)
+#else
+#    define rotl32(x, r) (((x) << (r)) | ((x) >> (32 - (r))))
+#endif
+
+    constexpr uint32_t PRIME32_1 = 0x9E3779B1U; /* 0b10011110001101110111100110110001 */
+    constexpr uint32_t PRIME32_2 = 0x85EBCA77U; /* 0b10000101111010111100101001110111 */
+    constexpr uint32_t PRIME32_3 = 0xC2B2AE3DU; /* 0b11000010101100101010111000111101 */
+    constexpr uint32_t PRIME32_4 = 0x27D4EB2FU; /* 0b00100111110101001110101100101111 */
+    constexpr uint32_t PRIME32_5 = 0x165667B1U; /* 0b00010110010101100110011110110001 */
+
+    static uint32_t XXH32_round(uint32_t acc, const uint32_t input)
     {
-        return (x << r) | (x >> (32 - r));
+        acc += input * PRIME32_2;
+        acc = rotl32(acc, 13);
+        acc *= PRIME32_1;
+        return acc;
     }
 
-    /// \brief MurmurHash3 is a non-cryptographic hash function initially designed
-    ///        for hash-based lookup.
-    ///
-    /// \sa It was written by Austin Appleby, and is placed in the public domain.
-    ///     The author hereby disclaims copyright to this source code:
-    ///     https://github.com/aappleby/smhasher/blob/master/src/MurmurHash3.cpp
+    uint32_t xxHash(const void * input, int32_t len, uint32_t seed) noexcept
+    {
+        uint32_t hash;
+
+        const auto * data = reinterpret_cast<const uint8_t *>(input);
+        if (len >= 16)
+        {
+            uint32_t v1 = seed + PRIME32_1 + PRIME32_2;
+            uint32_t v2 = seed + PRIME32_2;
+            uint32_t v3 = seed + 0;
+            uint32_t v4 = seed - PRIME32_1;
+
+            const uint8_t * const bEnd = data + len;
+            const uint8_t * const limit = bEnd - 15;
+            do
+            {
+                v1 = XXH32_round(v1, *reinterpret_cast<const uint32_t *>(data));
+                data += 4;
+                v2 = XXH32_round(v2, *reinterpret_cast<const uint32_t *>(data));
+                data += 4;
+                v3 = XXH32_round(v3, *reinterpret_cast<const uint32_t *>(data));
+                data += 4;
+                v4 = XXH32_round(v4, *reinterpret_cast<const uint32_t *>(data));
+                data += 4;
+            } while (data < limit);
+            len &= 15;
+
+            hash = rotl32(v1, 1) + rotl32(v2, 7) + rotl32(v3, 12) + rotl32(v4, 18);
+        }
+        else
+        {
+            hash = seed + PRIME32_5;
+        }
+        hash += static_cast<uint32_t>(len);
+
+        while (len >= 4)
+        {
+            hash += *reinterpret_cast<const uint32_t *>(data) * PRIME32_3;
+            data += 4;
+            hash = rotl32(hash, 17) * PRIME32_4;
+            len -= 4;
+        }
+        while (len > 0)
+        {
+            hash += *data * PRIME32_5;
+            data += 1;
+            hash = rotl32(hash, 11) * PRIME32_1;
+            --len;
+        }
+
+        hash ^= hash >> 15;
+        hash *= PRIME32_2;
+        hash ^= hash >> 13;
+        hash *= PRIME32_3;
+        hash ^= hash >> 16;
+        return hash;
+    }
+
     uint32_t MurmurHash3(const void * key, int32_t len, uint32_t seed) noexcept
     {
         // Define some internal constants
@@ -238,7 +308,6 @@ namespace jiminy
         h1 ^= h1 >> 13;
         h1 *= 0xc2b2ae35;
         h1 ^= h1 >> 16;
-
         return h1;
     }
 
@@ -403,8 +472,8 @@ namespace jiminy
         values_.noalias() += scale * cosMat_ * normalVec2;
 
         const auto diff =
-            2 * M_PI / period_ * Eigen::VectorXd::LinSpaced(
-                numHarmonics_, 1, static_cast<double>(numHarmonics_));
+            2 * M_PI / period_ *
+            Eigen::VectorXd::LinSpaced(numHarmonics_, 1, static_cast<double>(numHarmonics_));
         grads_ = scale * cosMat_ * normalVec1.cwiseProduct(diff);
         grads_.noalias() -= scale * sinMat_ * normalVec2.cwiseProduct(diff);
     }
@@ -416,7 +485,7 @@ namespace jiminy
         const MatrixX<Scalar> & state, int64_t sparsity, uint32_t seed) noexcept
     {
         const auto numBytes = static_cast<int32_t>(sizeof(Scalar) * state.size());
-        const uint32_t hash = MurmurHash3(state.data(), numBytes, seed);
+        const uint32_t hash = xxHash(state.data(), numBytes, seed);
         if (hash % sparsity == 0)
         {
             return static_cast<float>(hash) /
@@ -519,7 +588,10 @@ namespace jiminy
                 std::tie(height, dheight_x) = tile2dInterp1d(
                     posIndices, posRel, 0, size, sparsity, heightMax, interpThr, seed);
                 const double norm_inv = 1.0 / std::sqrt(dheight_x * dheight_x + 1.0);
-                normal << -dheight_x * norm_inv, 0.0, norm_inv;
+                if (normal.has_value())
+                {
+                    normal.value() << -dheight_x * norm_inv, 0.0, norm_inv;
+                }
             }
             else if (!is_edge[0] && is_edge[1])
             {
@@ -527,7 +599,10 @@ namespace jiminy
                 std::tie(height, dheight_y) = tile2dInterp1d(
                     posIndices, posRel, 1, size, sparsity, heightMax, interpThr, seed);
                 const double norm_inv = 1.0 / std::sqrt(dheight_y * dheight_y + 1.0);
-                normal << 0.0, -dheight_y * norm_inv, norm_inv;
+                if (normal.has_value())
+                {
+                    normal.value() << 0.0, -dheight_y * norm_inv, norm_inv;
+                }
             }
             else if (is_edge[0] && is_edge[1])
             {
@@ -544,8 +619,11 @@ namespace jiminy
                     const double dheight_x = dheight_x_0 + (dheight_x_m - dheight_x_0) * ratio;
                     const double dheight_y =
                         (height_0 - height_m) / (2.0 * size[1] * interpThr[1]);
-                    normal << -dheight_x, -dheight_y, 1.0;
-                    normal.normalize();
+                    if (normal.has_value())
+                    {
+                        normal.value() << -dheight_x, -dheight_y, 1.0;
+                        normal->normalize();
+                    }
                 }
                 else
                 {

--- a/python/jiminy_pywrap/include/jiminy/python/functors.h
+++ b/python/jiminy_pywrap/include/jiminy/python/functors.h
@@ -220,18 +220,25 @@ namespace jiminy::python
         {
         }
 
-        void operator()(
-            const Eigen::Vector2d & posFrame, double & height, Eigen::Ref<Eigen::Vector3d> normal)
+        void operator()(const Eigen::Vector2d & posFrame,
+                        double & height,
+                        std::optional<Eigen::Ref<Eigen::Vector3d>> normal)
         {
             switch (heightmapType_)
             {
             case HeightmapType::CONSTANT:
                 height = bp::extract<double>(handlePyPtr_);
-                normal = Eigen::Vector3d::UnitZ();
+                if (normal.has_value())
+                {
+                    normal.value() = Eigen::Vector3d::UnitZ();
+                }
                 break;
             case HeightmapType::STAIRS:
                 handlePyPtr_(posFrame, convertToPython(height, false));
-                normal = Eigen::Vector3d::UnitZ();
+                if (normal.has_value())
+                {
+                    normal.value() = Eigen::Vector3d::UnitZ();
+                }
                 break;
             case HeightmapType::GENERIC:
             default:

--- a/python/jiminy_pywrap/src/functors.cc
+++ b/python/jiminy_pywrap/src/functors.cc
@@ -41,8 +41,7 @@ namespace jiminy::python
         // Loop over all query points sequentially
         for (Eigen::Index i = 0; i < positions.cols(); ++i)
         {
-            Eigen::Vector3d normal;
-            heightmap(positions.col(i), heights[i], normal);
+            heightmap(positions.col(i), heights[i], std::nullopt);
         }
     }
 


### PR DESCRIPTION
* [core] Replace MurmurHash3 by xxHash32 which is faster.
* [core] Make gradient computation optional for heightmap functions.

Fixes https://github.com/duburcqa/jiminy/issues/666

The snippet mentioned here https://github.com/duburcqa/jiminy/pull/799#issuecomment-2226795064 is now taking 6us instead of 13us on my machine (3us if all points are co-located, 11us is they are extremely far away from each other). I don't think it is possible to do any better at this point without significant refactoring, but I think it is good enough now.

In particular, this meaningful snippet runs in 17us on my machine:
```python
import numpy as np
from jiminy_py.core import random_perlin_ground, query_heightmap

x_dim, y_dim = 20, 20
x_grid, y_grid = (np.linspace(-1.0, 1.0, i) for i in (x_dim, y_dim))
vertices = np.stack((
    np.tile(x_grid, y_dim),
    np.repeat(y_grid, x_dim),
    np.empty((x_dim * y_dim,))
), axis=0)

ground_fun = random_perlin_ground(wavelength=1.0, num_octaves=8, seed=42)
%timeit query_heightmap(ground_fun, vertices[:2], vertices[2])
```