### PR TITLE
[core] Various cleanup and bug fixes of Perlin processes.

### DIFF
--- a/core/src/utilities/geometry.cc
+++ b/core/src/utilities/geometry.cc
@@ -902,7 +902,7 @@ namespace jiminy
                 const auto grad = fun.grad(pos);
 
                 // Compute the inverse of the normal's Euclidean norm
-                const double normInv = 1.0 / grad.norm();
+                const double normInv = 1.0 / std::sqrt(1.0 + grad.squaredNorm());
 
                 // Update normal vector
                 normal.value() << -normInv * grad.template head<2>(), normInv;


### PR DESCRIPTION
`PeriodicPerlinProcess` is now significantly faster than `RandomPerlinProcess`, which is expected, since no hashing is involved at runtime. In practice, the expected speedup ranges from 30% to 50%.