### PR TITLE
[gym_jiminy/common] Stop relying on 'true' sensor measurements in computations.

### DIFF
--- a/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
@@ -196,7 +196,6 @@ class InterfaceJiminyEnv(
     robot: jiminy.Robot
     stepper_state: jiminy.StepperState
     robot_state: jiminy.RobotState
-    sensor_measurements: SensorMeasurementStackMap
     measurements: EngineObsType
     is_simulation_running: npt.NDArray[np.bool_]
 
@@ -281,6 +280,10 @@ class InterfaceJiminyEnv(
         :param v: Current extended velocity vector of the robot.
         :param sensor_measurements: Current sensor data.
         """
+        # Update engine measurement
+        measurement_flat = (t, q, v, *sensor_measurements.values())
+        multi_array_copyto(self._measurement_flat, measurement_flat)
+
         # Early return if no simulation is running
         if not self.is_simulation_running:
             return
@@ -305,14 +308,6 @@ class InterfaceJiminyEnv(
         # that is supposed to be executed before `refresh_observation` is being
         # called for the first time of an episode.
         if not self.__is_observation_refreshed:
-            # Update engine measurement
-            measurement_flat = (t, q, v, *sensor_measurements.values())
-            multi_array_copyto(self._measurement_flat, measurement_flat)
-
-            # Early return if no simulation is running
-            if not self.is_simulation_running:
-                return
-
             # Refresh observation
             try:
                 self.refresh_observation(self.measurement)

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
@@ -13,8 +13,12 @@ import numpy.typing as npt
 import gymnasium as gym
 
 import jiminy_py.core as jiminy
+from jiminy_py.core import (  # pylint: disable=no-name-in-module
+    multi_array_copyto)
 from jiminy_py.simulator import Simulator
 from jiminy_py.viewer.viewer import is_display_available
+
+import pinocchio as pin
 
 from ..utils import DataNested
 if TYPE_CHECKING:
@@ -193,6 +197,7 @@ class InterfaceJiminyEnv(
     stepper_state: jiminy.StepperState
     robot_state: jiminy.RobotState
     sensor_measurements: SensorMeasurementStackMap
+    measurements: EngineObsType
     is_simulation_running: npt.NDArray[np.bool_]
 
     num_steps: npt.NDArray[np.int64]
@@ -217,12 +222,24 @@ class InterfaceJiminyEnv(
         self.__is_observation_refreshed = True
 
         # Store latest engine measurement for efficiency
-        self.__measurement = EngineObsType(
+        self.measurement = EngineObsType(
             t=np.array(0.0),
             states=OrderedDict(
-                agent=OrderedDict(q=np.array([]), v=np.array([]))),
-            measurements=OrderedDict(self.robot.sensor_measurements))
+                agent=OrderedDict(
+                    q=pin.neutral(self.robot.pinocchio_model),
+                    v=np.zeros(self.robot.pinocchio_model.nv))),
+            measurements=OrderedDict(zip(
+                self.robot.sensor_measurements.keys(),
+                map(np.copy, self.robot.sensor_measurements.values()))))
         self._sensors_types = tuple(self.robot.sensor_measurements.keys())
+
+        # Define flattened engine measurement for efficiency
+        agent_state = self.measurement['states']['agent']
+        assert isinstance(agent_state, dict)
+        self._measurement_flat = (self.measurement['t'],
+                                  agent_state['q'],
+                                  agent_state['v'],
+                                  *self.measurement['measurements'].values())
 
         # Call super to allow mixing interfaces through multiple inheritance
         super().__init__(*args, **kwargs)
@@ -288,16 +305,17 @@ class InterfaceJiminyEnv(
         # that is supposed to be executed before `refresh_observation` is being
         # called for the first time of an episode.
         if not self.__is_observation_refreshed:
-            measurement = self.__measurement
-            measurement["t"][()] = t
-            measurement["states"]["agent"]["q"] = q
-            measurement["states"]["agent"]["v"] = v
-            measurement_sensors = measurement["measurements"]
-            sensor_measurements_it = iter(sensor_measurements.values())
-            for sensor_type in self._sensors_types:
-                measurement_sensors[sensor_type] = next(sensor_measurements_it)
+            # Update engine measurement
+            measurement_flat = (t, q, v, *sensor_measurements.values())
+            multi_array_copyto(self._measurement_flat, measurement_flat)
+
+            # Early return if no simulation is running
+            if not self.is_simulation_running:
+                return
+
+            # Refresh observation
             try:
-                self.refresh_observation(measurement)
+                self.refresh_observation(self.measurement)
             except RuntimeError as e:
                 raise RuntimeError(
                     "The observation space must be invariant.") from e

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -193,6 +193,10 @@ class BasePipelineWrapper(
         # Call base implementation
         super().__init__()  # Do not forward any argument
 
+        # Bind engine measurement
+        self.measurement = env.measurement
+        self._measurement_flat = env._measurement_flat
+
         # Enable direct forwarding by default for efficiency
         if BasePipelineWrapper.has_terminated is type(self).has_terminated:
             self.has_terminated = (  # type: ignore[method-assign]

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -180,7 +180,6 @@ class BasePipelineWrapper(
         self.stepper_state = env.stepper_state
         self.robot = env.robot
         self.robot_state = env.robot_state
-        self.sensor_measurements = env.sensor_measurements
         self.is_simulation_running = env.is_simulation_running
         self.num_steps = env.num_steps
 
@@ -437,7 +436,6 @@ class BasePipelineWrapper(
         # Refresh some proxies for fast lookup
         self.robot = self.env.robot
         self.robot_state = self.env.robot_state
-        self.sensor_measurements = self.env.sensor_measurements
 
         # Initialize specialized operator(s) for efficiency
         self._copyto_action = build_copyto(self.action)

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/deformation_estimator.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/deformation_estimator.py
@@ -698,9 +698,9 @@ class DeformationEstimator(BaseObserverBlock[
                     "Revolute unbounded joints are not supported for now.")
             self.encoder_to_position_map[sensor.index] = joint.idx_q
 
-        # Extract measured motor / joint positions for fast access.
-        # Note that they will be initialized in `_setup` method.
-        self.encoder_data = np.array([])
+        # Extract measured motor / joint positions for fast access
+        self.encoder_data, _ = (
+            env.measurement["measurements"][EncoderSensor.type])
 
         # Ratio to translate encoder data to joint side
         self.encoder_to_joint_ratio = np.array([])
@@ -782,9 +782,6 @@ class DeformationEstimator(BaseObserverBlock[
                 for frame_names in (flex_frame_names, imu_frame_names))
             self._kin_flex_rots.append(kin_flex_rots)
             self._kin_imu_rots.append(kin_imu_rots)
-
-        # Refresh measured motor position proxy
-        self.encoder_data, _ = self.env.sensor_measurements[EncoderSensor.type]
 
         # Refresh mechanical reduction ratio
         encoder_to_joint_ratio = []

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/motor_safety_limit.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/motor_safety_limit.py
@@ -172,9 +172,9 @@ class MotorSafetyLimit(
                 "Consider using the same ordering for encoders and motors for "
                 "optimal performance.")
 
-        # Extract measured motor positions and velocities for fast access.
-        # Note that they will be initialized in `_setup` method.
-        self.q_measured, self.v_measured = np.array([]), np.array([])
+        # Extract measured motor positions and velocities for fast access
+        self.q_measured, self.v_measured = (
+            env.measurement["measurements"][EncoderSensor.type])
 
         # Initialize the controller
         super().__init__(name, env, update_ratio=1)
@@ -185,14 +185,6 @@ class MotorSafetyLimit(
         The action spaces corresponds to the command motors efforts.
         """
         self.action_space = self.env.action_space
-
-    def _setup(self) -> None:
-        # Call base implementation
-        super()._setup()
-
-        # Refresh measured motor positions and velocities proxies
-        self.q_measured, self.v_measured = (
-            self.env.sensor_measurements[EncoderSensor.type])
 
     @property
     def fieldnames(self) -> List[str]:

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
@@ -384,9 +384,9 @@ class PDController(
                                               motors_velocity_limit,
                                               acceleration_limit], axis=0)
 
-        # Extract measured motor positions and velocities for fast access.
-        # Note that they will be initialized in `_setup` method.
-        self.q_measured, self.v_measured = np.array([]), np.array([])
+        # Extract measured motor positions and velocities for fast access
+        self.q_measured, self.v_measured = (
+            env.measurement["measurements"][EncoderSensor.type])
 
         # Allocate memory for the command state
         self._command_state = np.zeros((3, env.robot.nmotors))
@@ -429,10 +429,6 @@ class PDController(
         if self.env.control_dt <= 0.0:
             raise ValueError(
                 "This block does not support time-continuous update.")
-
-        # Refresh measured motor positions and velocities proxies
-        self.q_measured, self.v_measured = (
-            self.env.sensor_measurements[EncoderSensor.type])
 
         # Reset the command state
         fill(self._command_state, 0)

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -50,7 +50,6 @@ from ..bases import (DT_EPS,
                      Obs,
                      Act,
                      InfoType,
-                     SensorMeasurementStackMap,
                      EngineObsType,
                      InterfaceJiminyEnv)
 from ..quantities import QuantityManager
@@ -200,8 +199,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         self._robot_state_q = np.array([])
         self._robot_state_v = np.array([])
         self._robot_state_a = np.array([])
-        self.sensor_measurements: SensorMeasurementStackMap = OrderedDict(
-            self.robot.sensor_measurements)
 
         # Top-most block of the pipeline is the environment itself by default
         self.derived = self
@@ -563,7 +560,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # It is necessary because the robot may have changed.
         self.robot = self.simulator.robot
         self.robot_state = self.simulator.robot_state
-        self.sensor_measurements = OrderedDict(self.robot.sensor_measurements)
 
         # Reset action
         fill(self.action, 0)
@@ -670,8 +666,9 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Start the simulation
         self.simulator.start(q_init, v_init)
 
-        # Refresh robot_state proxies. It must be done here because memory is
-        # only allocated by the engine when starting a simulation.
+        # Refresh robot_state proxies.
+        # Note that it must be done here because memory is only allocated by
+        # the engine when starting a simulation.
         self._robot_state_q = self.robot_state.q
         self._robot_state_v = self.robot_state.v
         self._robot_state_a = self.robot_state.a
@@ -793,7 +790,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             # Update the action
             self._copyto_action(action)
 
-        # Try performing a single simulation step
+        # Try performing a single environment step
         try:
             self.simulator.step(self.step_dt)
         except Exception:

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/internal/play.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/internal/play.py
@@ -64,7 +64,7 @@ class Getch:
         return it. Any previous characters not fetched before calling this
         method will be discarded.
         """
-        if os.name == "nt":
+        if os.name == "posix":
             char = ''
             try:
                 import termios

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/misc.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/misc.py
@@ -34,7 +34,7 @@ class RandomDistribution(Protocol):
         ...
 
 
-def is_breakpoint(t: float, dt: float, eps: float) -> bool:
+def is_breakpoint(t: ArrayOrScalar, dt: float, eps: float) -> bool:
     """Check if 't' is multiple of 'dt' at a given precision 'eps'.
 
     :param t: Current time.
@@ -45,8 +45,8 @@ def is_breakpoint(t: float, dt: float, eps: float) -> bool:
     """
     if dt < eps:
         return True
-    dt_prev = t % dt
-    return (dt_prev < eps / 2) or (dt - dt_prev <= eps / 2)
+    dt_prev = float(t) % dt
+    return (dt_prev < eps) or (dt - dt_prev <= eps)
 
 
 @nb.jit(nopython=True, cache=True, inline='always')

--- a/python/gym_jiminy/common/gym_jiminy/common/wrappers/observation_stack.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/wrappers/observation_stack.py
@@ -10,7 +10,7 @@ from typing import (
 import numpy as np
 import gymnasium as gym
 from jiminy_py.core import (  # pylint: disable=no-name-in-module
-    is_breakpoint, array_copyto, multi_array_copyto)
+    array_copyto, multi_array_copyto)
 from jiminy_py.tree import flatten_with_path, unflatten_as
 
 from ..bases import (DT_EPS,
@@ -19,7 +19,7 @@ from ..bases import (DT_EPS,
                      EngineObsType,
                      InterfaceJiminyEnv,
                      BasePipelineWrapper)
-from ..utils import zeros, copy
+from ..utils import zeros, copy, is_breakpoint
 
 
 StackedObs: TypeAlias = NestedObs
@@ -220,7 +220,7 @@ class StackObservation(
 
     def refresh_observation(self, measurement: EngineObsType) -> None:
         # Skip update if nothing to do
-        if not is_breakpoint(self.stepper_state, self.observe_dt, DT_EPS):
+        if not is_breakpoint(measurement["t"], self.observe_dt, DT_EPS):
             return
 
         # Refresh environment observation
@@ -231,7 +231,7 @@ class StackObservation(
         if self.is_simulation_running:
             self._n_last_stack += 1
             if self.skip_frames_ratio < 0:
-                if is_breakpoint(self.stepper_state, self._step_dt, DT_EPS):
+                if is_breakpoint(measurement["t"], self._step_dt, DT_EPS):
                     update_stack = True
             elif self._n_last_stack == self.skip_frames_ratio:
                 update_stack = True

--- a/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/cartpole.py
@@ -215,10 +215,12 @@ class CartPoleJiminyEnv(BaseJiminyEnv[np.ndarray, np.ndarray]):
         return 1.0 if not terminated else 0.0
 
     def _key_to_action(self,
-                       key: str,
+                       key: Optional[str],
                        obs: np.ndarray,
                        reward: Optional[float],
                        **kwargs: Any) -> Optional[np.ndarray]:
+        if key is None:
+            return None
         if key == "Left":
             return np.array(1)
         if key == "Right":

--- a/python/gym_jiminy/unit_py/test_deformation_estimator.py
+++ b/python/gym_jiminy/unit_py/test_deformation_estimator.py
@@ -188,16 +188,6 @@ class DeformationEstimatorBlock(unittest.TestCase):
                     self.robot.attach_sensor(sensor)
                     sensor.initialize(frame_name)
 
-            def _setup(self) -> None:
-                # Call base implementation
-                super()._setup()
-
-                # Configure the controller and sensor update periods
-                engine_options = self.simulator.get_options()
-                engine_options['stepper']['controllerUpdatePeriod'] = 0.0001
-                engine_options['stepper']['sensorsUpdatePeriod'] = 0.0001
-                self.simulator.set_options(engine_options)
-
                 # Add flexibility frames
                 model_options = self.robot.get_model_options()
                 model_options["dynamics"]["flexibilityConfig"] = []
@@ -212,6 +202,25 @@ class DeformationEstimatorBlock(unittest.TestCase):
                     )
                 model_options["dynamics"]["enableFlexibility"] = True
                 self.robot.set_model_options(model_options)
+
+                # Re-Initialize base class to take into account new sensors
+                BaseJiminyEnv.__init__(
+                    self,
+                    simulator=self.simulator,
+                    debug=debug,
+                    **{**dict(
+                        step_dt=self.step_dt),
+                        **kwargs})
+
+            def _setup(self) -> None:
+                # Call base implementation
+                super()._setup()
+
+                # Configure the controller and sensor update periods
+                engine_options = self.simulator.get_options()
+                engine_options['stepper']['controllerUpdatePeriod'] = 0.0001
+                engine_options['stepper']['sensorsUpdatePeriod'] = 0.0001
+                self.simulator.set_options(engine_options)
 
         # Create pipeline with Mahony filter and DeformationEstimator blocks
         PipelineEnv = build_pipeline(

--- a/python/jiminy_pywrap/src/helpers.cc
+++ b/python/jiminy_pywrap/src/helpers.cc
@@ -113,17 +113,6 @@ namespace jiminy::python
         return bp::extract<np::ndarray>(objPy);
     }
 
-    bool isBreakpoint(StepperState & stepperState, double dt, double eps)
-    {
-        if (dt < eps)
-        {
-            return true;
-        }
-        const double dtPrev = std::fmod(stepperState.t, dt);
-        const double dtNext = dt - dtPrev;
-        return (dtPrev < eps) || (dtNext < eps);
-    }
-
     template<typename T>
     void EigenMapTransposeAssign(char * dstData, char * srcData, npy_intp rows, npy_intp cols)
     {
@@ -407,8 +396,6 @@ namespace jiminy::python
                 &getFrameIndices,
                 bp::return_value_policy<result_converter<true>>(),
                 (bp::arg("pinocchio_model"), "joint_names"));
-
-        bp::def("is_breakpoint", &isBreakpoint, (bp::arg("stepper_state"), "dt", "eps"));
 
         bp::def("array_copyto", &arrayCopyTo, (bp::arg("dst"), "src"));
         bp::def("multi_array_copyto", &multiArrayCopyTo, (bp::arg("dst"), "src"));


### PR DESCRIPTION
* [gym_jiminy/common] Fix 'BaseJiminyEnv.play_interactive'.
* [gym_jiminy/common] Share base engine measurement through all the layers of the pipeline.
* [gym_jiminy/common] Stop relying on 'true' sensor measurements in computations.
* [gym_jiminy/common] Stop relying on stepper_state to get current time.