### PR TITLE
[core] Fix several edge-cases mainly related to impulse forces.

### DIFF
--- a/core/examples/double_pendulum/double_pendulum.cc
+++ b/core/examples/double_pendulum/double_pendulum.cc
@@ -91,6 +91,7 @@ int main(int /* argc */, char * /* argv */[])
     GenericConfig simuOptions = engine.getOptions();
     GenericConfig & telemetryOptions = boost::get<GenericConfig>(simuOptions.at("telemetry"));
     boost::get<bool>(telemetryOptions.at("isPersistent")) = true;
+    boost::get<bool>(telemetryOptions.at("logInternalStepperSteps")) = false;
     boost::get<bool>(telemetryOptions.at("enableConfiguration")) = true;
     boost::get<bool>(telemetryOptions.at("enableVelocity")) = true;
     boost::get<bool>(telemetryOptions.at("enableAcceleration")) = true;
@@ -110,7 +111,6 @@ int main(int /* argc */, char * /* argv */[])
     boost::get<double>(stepperOptions.at("timeout")) = -1;         // -1 to disable
     boost::get<double>(stepperOptions.at("sensorsUpdatePeriod")) = 1.0e-3;
     boost::get<double>(stepperOptions.at("controllerUpdatePeriod")) = 1.0e-3;
-    boost::get<bool>(stepperOptions.at("logInternalStepperSteps")) = false;
     boost::get<VectorX<uint32_t>>(stepperOptions.at("randomSeedSeq")) =
         VectorX<uint32_t>::Zero(1);  // `time(nullptr)` for random seed
     GenericConfig & contactsOptions = boost::get<GenericConfig>(simuOptions.at("contacts"));

--- a/core/include/jiminy/core/engine/engine.h
+++ b/core/include/jiminy/core/engine/engine.h
@@ -320,7 +320,6 @@ namespace jiminy
             config["timeout"] = 0.0;  // <= 0.0: disable
             config["sensorsUpdatePeriod"] = 0.0;
             config["controllerUpdatePeriod"] = 0.0;
-            config["logInternalStepperSteps"] = false;
 
             return config;
         };
@@ -329,6 +328,7 @@ namespace jiminy
         {
             GenericConfig config;
             config["isPersistent"] = false;
+            config["logInternalStepperSteps"] = false;
             config["enableConfiguration"] = true;
             config["enableVelocity"] = true;
             config["enableAcceleration"] = true;
@@ -416,7 +416,6 @@ namespace jiminy
             const double timeout;
             const double sensorsUpdatePeriod;
             const double controllerUpdatePeriod;
-            const bool logInternalStepperSteps;
 
             StepperOptions(const GenericConfig & options) :
             verbose{boost::get<bool>(options.at("verbose"))},
@@ -430,8 +429,7 @@ namespace jiminy
             iterMax{boost::get<uint32_t>(options.at("iterMax"))},
             timeout{boost::get<double>(options.at("timeout"))},
             sensorsUpdatePeriod{boost::get<double>(options.at("sensorsUpdatePeriod"))},
-            controllerUpdatePeriod{boost::get<double>(options.at("controllerUpdatePeriod"))},
-            logInternalStepperSteps{boost::get<bool>(options.at("logInternalStepperSteps"))}
+            controllerUpdatePeriod{boost::get<double>(options.at("controllerUpdatePeriod"))}
             {
             }
         };
@@ -439,6 +437,7 @@ namespace jiminy
         struct TelemetryOptions
         {
             const bool isPersistent;
+            const bool logInternalStepperSteps;
             const bool enableConfiguration;
             const bool enableVelocity;
             const bool enableAcceleration;
@@ -450,6 +449,7 @@ namespace jiminy
 
             TelemetryOptions(const GenericConfig & options) :
             isPersistent{boost::get<bool>(options.at("isPersistent"))},
+            logInternalStepperSteps{boost::get<bool>(options.at("logInternalStepperSteps"))},
             enableConfiguration{boost::get<bool>(options.at("enableConfiguration"))},
             enableVelocity{boost::get<bool>(options.at("enableVelocity"))},
             enableAcceleration{boost::get<bool>(options.at("enableAcceleration"))},
@@ -775,8 +775,7 @@ namespace jiminy
     private:
         template<typename Scalar,
                  int Options,
-                 template<typename, int>
-                 class JointCollectionTpl,
+                 template<typename, int> class JointCollectionTpl,
                  typename ConfigVectorType,
                  typename TangentVectorType>
         inline Scalar
@@ -787,8 +786,7 @@ namespace jiminy
                       bool update_kinematics);
         template<typename Scalar,
                  int Options,
-                 template<typename, int>
-                 class JointCollectionTpl,
+                 template<typename, int> class JointCollectionTpl,
                  typename ConfigVectorType,
                  typename TangentVectorType1,
                  typename TangentVectorType2,
@@ -803,8 +801,7 @@ namespace jiminy
                  const vector_aligned_t<ForceDerived> & fext);
         template<typename Scalar,
                  int Options,
-                 template<typename, int>
-                 class JointCollectionTpl,
+                 template<typename, int> class JointCollectionTpl,
                  typename ConfigVectorType,
                  typename TangentVectorType1,
                  typename TangentVectorType2,

--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -3720,11 +3720,11 @@ namespace jiminy
                    often. */
                 if ((fext[i].toVector().array().abs() > EPS).any())
                 {
-                    if (!isStateUpToDate)
-                    {
-                        pinocchio::getJointJacobian(
-                            model, data, i, pinocchio::LOCAL, robotData.jointJacobians[i]);
-                    }
+                    /* The jacobian only depends on the position, which means that updating it
+                       could be skipped in principle. However, it is only computed if need, and as
+                       such, one cannot count on it. */
+                    pinocchio::getJointJacobian(
+                        model, data, i, pinocchio::LOCAL, robotData.jointJacobians[i]);
                     data.u.noalias() +=
                         robotData.jointJacobians[i].transpose() * fext[i].toVector();
                 }

--- a/core/src/stepper/abstract_runge_kutta_stepper.cc
+++ b/core/src/stepper/abstract_runge_kutta_stepper.cc
@@ -57,6 +57,7 @@ namespace jiminy
         state.sum(stateIncrement_, candidateSolution_);
 
         // Evaluate the solution's error for step adjustment
+        const double t_next = t + dt;
         const bool hasSucceeded = adjustStep(state, candidateSolution_, dt);
 
         // Update state and compute derivative if success
@@ -69,7 +70,7 @@ namespace jiminy
             }
             else
             {
-                stateDerivative = f(t, state);
+                stateDerivative = f(t_next, state);
             }
         }
 

--- a/core/src/stepper/abstract_stepper.cc
+++ b/core/src/stepper/abstract_stepper.cc
@@ -23,7 +23,7 @@ namespace jiminy
         stepper::StatusInfo status{stepper::ReturnCode::IS_SUCCESS, {}};
 
         // Update buffers
-        double t_next = t + dt;
+        const double t_next = t + dt;
         state_.q = qSplit;
         state_.v = vSplit;
         stateDerivative_.v = vSplit;

--- a/core/src/stepper/euler_explicit_stepper.cc
+++ b/core/src/stepper/euler_explicit_stepper.cc
@@ -10,7 +10,8 @@ namespace jiminy
         state.sumInPlace(stateDerivative, dt);
 
         // Compute the next state derivative
-        stateDerivative = f(t, state);
+        const double t_next = t + dt;
+        stateDerivative = f(t_next, state);
 
         /* By default INF is returned no matter what for fixed-timestep integrators.
            The user is responsible for managing it externally. */

--- a/data/bipedal_robots/atlas/atlas_options.toml
+++ b/data/bipedal_robots/atlas/atlas_options.toml
@@ -7,8 +7,12 @@ tolAbs = 1e-5
 tolRel = 1e-4
 sensorsUpdatePeriod = 0.005
 controllerUpdatePeriod = 0.005
-logInternalStepperSteps = false
 randomSeedSeq = [0,]
+
+# ============= Engine telemetry =================
+
+[engine.telemetry]
+logInternalStepperSteps = false
 
 # ============== Contact dynamics ===============
 

--- a/data/bipedal_robots/cassie/cassie_options.toml
+++ b/data/bipedal_robots/cassie/cassie_options.toml
@@ -7,8 +7,12 @@ tolAbs = 1e-5
 tolRel = 1e-4
 sensorsUpdatePeriod = 0.005
 controllerUpdatePeriod = 0.005
-logInternalStepperSteps = false
 randomSeedSeq = [0,]
+
+# ============== Telemetry options ===============
+
+[engine.telemetry]
+logInternalStepperSteps = false
 
 # ============== Contact dynamics ===============
 

--- a/data/bipedal_robots/digit/digit_options.toml
+++ b/data/bipedal_robots/digit/digit_options.toml
@@ -7,8 +7,12 @@ tolAbs = 1e-5
 tolRel = 1e-4
 sensorsUpdatePeriod = 0.005
 controllerUpdatePeriod = 0.005
-logInternalStepperSteps = false
 randomSeedSeq = [0,]
+
+# ============== Telemetry options ===============
+
+[engine.telemetry]
+logInternalStepperSteps = false
 
 # ============== Contact dynamics ===============
 

--- a/data/quadrupedal_robots/anymal/anymal_options.toml
+++ b/data/quadrupedal_robots/anymal/anymal_options.toml
@@ -7,8 +7,12 @@ tolAbs = 1e-5
 tolRel = 1e-4
 sensorsUpdatePeriod = 0.005
 controllerUpdatePeriod = 0.005
-logInternalStepperSteps = false
 randomSeedSeq = [0,]
+
+# ============== Telemetry options ===============
+
+[engine.telemetry]
+logInternalStepperSteps = false
 
 # ============== Contact dynamics ===============
 

--- a/data/toys_models/ant/ant_options.toml
+++ b/data/toys_models/ant/ant_options.toml
@@ -5,8 +5,12 @@ verbose = false
 odeSolver = "runge_kutta_4"
 sensorsUpdatePeriod = 0.01
 controllerUpdatePeriod = 0.01
-logInternalStepperSteps = false
 randomSeedSeq = [0,]
+
+# ============== Telemetry options ===============
+
+[engine.telemetry]
+logInternalStepperSteps = false
 
 # ============== Contact dynamics ===============
 

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
@@ -444,6 +444,9 @@ class PDController(
         # Initialize the controller
         super().__init__(name, env, update_ratio)
 
+        # Whether deadband is enabled
+        self._enable_deadband = False
+
         # Make sure that the state is within bounds
         self._command_state[:2] = zeros(self.state_space)
 
@@ -482,6 +485,10 @@ class PDController(
 
         # Reset the command state
         fill(self._command_state, 0)
+
+        # Enable deadband in evaluation mode only.
+        # Note that training/evaluation cannot be changed at this point.
+        self._enable_deadband = not self.env.is_training
 
     @property
     def fieldnames(self) -> List[str]:
@@ -533,7 +540,7 @@ class PDController(
             self.kp,
             self.kd,
             self.motors_effort_limit,
-            None if self.env.is_training else self._motors_velocity_deadband,
+            self._motors_velocity_deadband if self._enable_deadband else None,
             self.control_dt if is_simulation_running else 0.0,
             command)
 

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -657,9 +657,10 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         self.robot.controller = jiminy.FunctionalController(
             partial(type(env)._controller_handle, weakref.proxy(env)))
 
-        # Register user-specified variables to the telemetry
-        for header, value in self._registered_variables.values():
-            register_variables(self.robot.controller, header, value)
+        # Register user-specified variables to the telemetry in evaluation mode
+        if self.debug or not self.is_training:
+            for header, value in self._registered_variables.values():
+                register_variables(self.robot.controller, header, value)
 
         # Start the simulation
         self.simulator.start(q_init, v_init)

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -201,6 +201,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         self._robot_state_q = np.array([])
         self._robot_state_v = np.array([])
         self._robot_state_a = np.array([])
+        self._sensor_measurements = self.robot.sensor_measurements
 
         # Top-most block of the pipeline is the environment itself by default
         self.derived = self
@@ -565,6 +566,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # It is necessary because the robot may have changed.
         self.robot = self.simulator.robot
         self.robot_state = self.simulator.robot_state
+        self._sensor_measurements = self.robot.sensor_measurements
 
         # Reset action
         fill(self.action, 0)
@@ -692,7 +694,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             self.stepper_state.t,
             self._robot_state_q,
             self._robot_state_v,
-            self.robot.sensor_measurements)
+            self._sensor_measurements)
 
         # Initialize specialized most-derived observation clipping operator
         self._get_clipped_env_observation = build_clip(
@@ -825,7 +827,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             self.stepper_state.t,
             self._robot_state_q,
             self._robot_state_v,
-            self.robot.sensor_measurements)
+            self._sensor_measurements)
 
         # Reset the extra information buffer
         self._info.clear()

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -7,7 +7,6 @@ import math
 import weakref
 import logging
 import tempfile
-from copy import deepcopy
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
 from functools import partial
@@ -737,7 +736,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             if viewer.has_gui():
                 viewer.refresh()
 
-        return obs, deepcopy(self._info)
+        return obs, tree.deepcopy(self._info)
 
     def close(self) -> None:
         """Clean up the environment after the user has finished using it.
@@ -871,7 +870,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Clip (and copy) the most derived observation before returning it
         obs = self._get_clipped_env_observation()
 
-        return obs, reward, terminated, truncated, deepcopy(self._info)
+        return obs, reward, terminated, truncated, tree.deepcopy(self._info)
 
     def stop(self) -> None:
         # Check whether it is worth saving log file

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -589,15 +589,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         self.num_steps[()] = 0
         self._num_steps_beyond_terminate = None
 
-        # Extract the observer/controller update period.
-        # The controller update period is used by default for the observer if
-        # it was not specify by the user in `_setup`.
-        engine_options = self.simulator.get_options()
-        self.control_dt = float(
-            engine_options['stepper']['controllerUpdatePeriod'])
-        if self.observe_dt < 0.0:
-            self.observe_dt = self.control_dt
-
         # Make sure that both the observer and the controller are running
         # faster than the environment to which it is attached for the action to
         # take effect and be observable. Moreover, their respective update
@@ -1260,8 +1251,15 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Backup simulation options
         self._simu_options_orig = self.simulator.get_simulation_options()
 
-        # Configure the low-level integrator
+        # Extract the observer/controller update period.
+        # The controller update period is used by default for the observer if
+        # it was not specify by the user in `_setup`.
         engine_options = self.simulator.get_options()
+        self.control_dt = float(
+            engine_options['stepper']['controllerUpdatePeriod'])
+        self.observe_dt = self.control_dt
+
+        # Configure the low-level integrator
         engine_options["stepper"]["iterMax"] = 0
         if self.debug:
             engine_options["stepper"]["verbose"] = True

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -1264,8 +1264,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         engine_options["stepper"]["iterMax"] = 0
         if self.debug:
             engine_options["stepper"]["verbose"] = True
-        if self.debug or not self.is_training:
-            engine_options["stepper"]["logInternalStepperSteps"] = True
 
         # Set maximum computation time for single internal integration steps
         engine_options["stepper"]["timeout"] = self.step_dt * TIMEOUT_RATIO
@@ -1285,6 +1283,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             # that the robot can be loaded on any machine with access to the
             # original URDF and mesh files.
             engine_options["telemetry"]["isPersistent"] = True
+            engine_options["telemetry"]["logInternalStepperSteps"] = True
 
             # Enable all telemetry data at robot-level
             robot_options = self.robot.get_options()

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -941,8 +941,8 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 "Nothing to plot. Please run a simulation before calling "
                 "`plot` method.")
 
-        # Plot all registered variables
-        for key, fieldnames in self.log_fieldnames.items():
+        # Plot all registered variables from high-level to low-level blocks
+        for key, fieldnames in reversed(list(self.log_fieldnames.items())):
             # Filter state if requested
             if not enable_block_states and key.endswith(".state"):
                 continue

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
@@ -24,7 +24,7 @@ from ..bases import (
     InterfaceJiminyEnv, InterfaceQuantity, AbstractQuantity, StateQuantity,
     QuantityEvalMode)
 from ..utils import (
-    matrix_to_rpy, matrix_to_quat, quat_apply, remove_yaw_from_quat,
+    mean, matrix_to_rpy, matrix_to_quat, quat_apply, remove_yaw_from_quat,
     quat_interpolate_middle)
 
 from .transform import (
@@ -1826,4 +1826,4 @@ class AverageMechanicalPowerConsumption(InterfaceQuantity[float]):
             auto_refresh=False)
 
     def refresh(self) -> float:
-        return np.mean(self.total_power_stack.get())
+        return mean(self.total_power_stack.get())

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/transform.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/transform.py
@@ -12,6 +12,7 @@ from typing import (
 
 import numpy as np
 
+from jiminy_py import tree
 from jiminy_py.core import (  # pylint: disable=no-name-in-module
     array_copyto, multi_array_copyto)
 
@@ -207,7 +208,7 @@ class StackedQuantity(
                 else:
                     if len(value_list) == self.max_stack:
                         del value_list[0]
-                    value_list.append(deepcopy(value))
+                    value_list.append(tree.deepcopy(value))
                 self._num_steps_prev += 1
 
         # Aggregate data in contiguous array only if requested

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/transform.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/transform.py
@@ -4,7 +4,6 @@ application (locomotion, grasping...).
 """
 import sys
 import warnings
-from copy import deepcopy
 from dataclasses import dataclass
 from types import EllipsisType
 from typing import (

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/__init__.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring
 
-from .math import (exp3,
+from .math import (mean,
+                   exp3,
                    exp6,
                    log3,
                    log6,
@@ -58,6 +59,7 @@ from .pipeline import (save_trajectory_to_hdf5,
 
 
 __all__ = [
+    'mean',
     'exp3',
     'exp6',
     'log3',

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/math.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/math.py
@@ -15,6 +15,46 @@ from .spaces import ArrayOrScalar
 TWIST_SWING_SINGULAR_THR = 1e-5
 
 
+@nb.jit(nopython=True, cache=True, inline='always')
+def _mean(array: np.ndarray) -> np.ndarray:
+    """Compute the arithmetic mean over flattened array.
+
+    :param array: Input array.
+    """
+    return np.mean(array)
+
+
+@nb.jit(nopython=True, cache=True, inline='always')
+def _mean_axis(array: np.ndarray, axis: int) -> np.ndarray:
+    """Compute the arithmetic mean along a given axis.
+
+    :param array: Input array.
+    """
+    return np.sum(array, axis) / array.shape[axis]
+
+
+@overload
+def mean(array: np.ndarray, axis: int) -> np.ndarray:
+    ...
+
+
+@overload
+def mean(array: np.ndarray, axis: Literal[None] = ...) -> float:
+    ...
+
+
+def mean(array: np.ndarray,
+         axis: Optional[int] = None) -> Union[float, np.ndarray]:
+    """Compute the arithmetic mean along the specified axis if specified, over
+    the flattened array otherwise.
+
+    :param array: Input array.
+    """
+    if axis is None:
+        return _mean(array)
+    return _mean_axis(array, axis)
+
+
 @overload
 def matrix_to_yaw(mat: np.ndarray, out: np.ndarray) -> None:
     ...

--- a/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
+++ b/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
@@ -58,7 +58,7 @@ def compute_convex_hull_vertices(points: np.ndarray) -> np.ndarray:
 
     .. seealso::
         Internally, it leverages using Andrew's monotone chain algorithm, which
-        as almost optimal complexity O(n*log(n)) but is only applicable in 2D
+        has almost optimal complexity O(n*log(n)) but is only applicable in 2D
         space. For an overview of all the existing algorithms to this day, see:
         https://en.wikipedia.org/wiki/Convex_hull_algorithms
 

--- a/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
+++ b/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
@@ -20,6 +20,7 @@ except ImportError:
     Figure = type(None)  # type: ignore[misc,assignment,unused-ignore]
 
 from jiminy_py.viewer import interactive_mode
+from gym_jiminy.common.utils import mean
 
 
 @nb.jit(nopython=True, cache=True, inline='always')
@@ -28,9 +29,9 @@ def _amin_last_axis(array: np.ndarray) -> np.ndarray:
 
     :param array: Input array.
     """
-    res = np.empty(array.shape[0])
-    for i in range(array.shape[0]):
-        res[i] = np.min(array[i])
+    res = np.empty(len(array), dtype=array.dtype)
+    for i, row in enumerate(array):
+        res[i] = np.min(row)
     return res
 
 
@@ -41,9 +42,9 @@ def _all_last_axis(array: np.ndarray) -> np.ndarray:
 
     :param array: Input array.
     """
-    res = np.empty(array.shape[0], dtype=np.bool_)
-    for i in range(array.shape[0]):
-        res[i] = np.all(array[i])
+    res = np.empty(len(array), dtype=np.bool_)
+    for i, row in enumerate(array):
+        res[i] = np.all(row)
     return res
 
 
@@ -410,7 +411,7 @@ class ConvexHull2D:
             to compute than the barycenter. For details about the Chebyshev
             center, see `compute_convex_chebyshev_center`.
         """
-        return np.mean(self.vertices, axis=0)
+        return mean(self.vertices, axis=0)
 
     def get_distance_to_point(self, points: np.ndarray) -> np.ndarray:
         """Compute the signed distance of a single or a batch of query points

--- a/python/gym_jiminy/unit_py/test_deformation_estimator.py
+++ b/python/gym_jiminy/unit_py/test_deformation_estimator.py
@@ -212,14 +212,10 @@ class DeformationEstimatorBlock(unittest.TestCase):
                         step_dt=self.step_dt),
                         **kwargs})
 
-            def _setup(self) -> None:
-                # Call base implementation
-                super()._setup()
-
                 # Configure the controller and sensor update periods
                 engine_options = self.simulator.get_options()
-                engine_options['stepper']['controllerUpdatePeriod'] = 0.0001
-                engine_options['stepper']['sensorsUpdatePeriod'] = 0.0001
+                engine_options['stepper']['controllerUpdatePeriod'] = 0.0002
+                engine_options['stepper']['sensorsUpdatePeriod'] = 0.0002
                 self.simulator.set_options(engine_options)
 
         # Create pipeline with Mahony filter and DeformationEstimator blocks

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -47,6 +47,7 @@ class PipelineControl(unittest.TestCase):
         """ TODO: Write documentation
         """
         # Reset the environment
+        self.env.eval()
         self.env.reset(seed=0)
 
         # Zero target motors velocities, so that the robot stands still
@@ -272,6 +273,7 @@ class PipelineControl(unittest.TestCase):
         controller._command_state_upper[2] = float("inf")
 
         # Run a few environment steps
+        env.eval()
         env.reset(seed=0)
         env.unwrapped._height_neutral = float("-inf")
         while env.stepper_state.t < 2.0:
@@ -282,13 +284,13 @@ class PipelineControl(unittest.TestCase):
         adapter_name, controller_name = adapter.name, controller.name
         n_motors = len(controller.fieldnames)
         target_pos = env.log_data["variables"][".".join((
-            "controller", controller_name, "state", str(n_motors - 1)))]
+            "controller", controller_name, "state", str(n_motors - 1)))][1::2]
         target_vel = env.log_data["variables"][".".join((
-            "controller", controller_name, "state", str(2 * n_motors - 1)))]
+            "controller", controller_name, "state", str(2 * n_motors - 1)))][1::2]
         target_accel = env.log_data["variables"][".".join((
-            "controller", controller_name, controller.fieldnames[-1]))]
+            "controller", controller_name, controller.fieldnames[-1]))][1::2]
         command_vel = env.log_data["variables"][".".join((
-            "controller", adapter_name, adapter.fieldnames[-1]))]
+            "controller", adapter_name, adapter.fieldnames[-1]))][1::2]
 
         # Make sure that the position and velocity targets are consistent
         target_vel_diff = np.diff(target_pos) / controller.control_dt

--- a/python/gym_jiminy/unit_py/test_pipeline_design.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_design.py
@@ -237,7 +237,7 @@ class PipelineDesign(unittest.TestCase):
         def configure_telemetry() -> InterfaceJiminyEnv:
             engine_options = env.simulator.get_options()
             engine_options['telemetry']['enableCommand'] = True
-            engine_options['stepper']['logInternalStepperSteps'] = False
+            engine_options['telemetry']['logInternalStepperSteps'] = False
             env.simulator.set_options(engine_options)
             return env
 

--- a/python/jiminy_py/examples/box_uneven_ground_impulse_contact.py
+++ b/python/jiminy_py/examples/box_uneven_ground_impulse_contact.py
@@ -36,7 +36,7 @@ if __name__ == '__main__':
     engine_options["constraints"]['regularization'] = 0.0
 
     # Configure integrator
-    engine_options["stepper"]['logInternalStepperSteps'] = True
+    engine_options["telemetry"]['logInternalStepperSteps'] = True
     engine_options['stepper']['odeSolver'] = 'runge_kutta_dopri'
     engine_options['stepper']['dtMax'] = 1.0e-3
 

--- a/python/jiminy_py/examples/double_pendulum.py
+++ b/python/jiminy_py/examples/double_pendulum.py
@@ -49,6 +49,7 @@ if __name__ == '__main__':
 
     robot_options["telemetry"]["enableImuSensors"] = True
     engine_options["telemetry"]["isPersistent"] = True
+    engine_options["telemetry"]["logInternalStepperSteps"] = False
     engine_options["telemetry"]["enableConfiguration"] = True
     engine_options["telemetry"]["enableVelocity"] = True
     engine_options["telemetry"]["enableAcceleration"] = True
@@ -63,7 +64,6 @@ if __name__ == '__main__':
     engine_options["stepper"]["dtMax"] = 2.0e-3  # 2.0e-4 for "euler_explicit", 3.0e-3 for "runge_kutta_dopri"
     engine_options["stepper"]["sensorsUpdatePeriod"] = 1.0e-3
     engine_options["stepper"]["controllerUpdatePeriod"] = 1.0e-3
-    engine_options["stepper"]["logInternalStepperSteps"] = False
     engine_options["stepper"]["randomSeedSeq"] = np.array([0,], dtype=np.uint32)
     engine_options['contacts']['model'] = "spring_damper"
     engine_options['contacts']['stiffness'] = 1.0e6

--- a/python/jiminy_py/src/jiminy_py/robot.py
+++ b/python/jiminy_py/src/jiminy_py/robot.py
@@ -488,11 +488,10 @@ def generate_default_hardware_description_file(
             assert joint_limit_descr is not None
             if float(joint_limit_descr.attrib['effort']) == 0.0:
                 continue
-            motors_info[SimpleMotor.type][joint_name] = OrderedDict(
+            motors_info['SimpleMotor'][joint_name] = OrderedDict(
                 joint_name=joint_name,
                 armature=0.0,
-                **joints_options.pop(joint_name)
-            )
+                **joints_options.pop(joint_name))
             sensors_info[EffortSensor.type][joint_name] = OrderedDict(
                 motor_name=joint_name)
 

--- a/python/jiminy_py/unit_py/test_foot_pendulum.py
+++ b/python/jiminy_py/unit_py/test_foot_pendulum.py
@@ -39,12 +39,12 @@ class SimulateFootedPendulum(unittest.TestCase):
 
         # Set options
         engine_options = simulator.get_options()
+        engine_options["telemetry"]["logInternalStepperSteps"] = True
         engine_options["telemetry"]["enableConfiguration"] = True
         engine_options["stepper"]["odeSolver"] = "runge_kutta_4"
         engine_options["stepper"]["dtMax"] = 1.0e-5
         engine_options["stepper"]["sensorsUpdatePeriod"] = 0.0
         engine_options["stepper"]["controllerUpdatePeriod"] = 1.0e-3
-        engine_options["stepper"]["logInternalStepperSteps"] = True
         engine_options['contacts']['model'] = "constraint"
         engine_options['contacts']['stabilizationFreq'] = 0.0
         engine_options['constraints']['regularization'] = 1e-9

--- a/python/jiminy_py/unit_py/test_simple_pendulum.py
+++ b/python/jiminy_py/unit_py/test_simple_pendulum.py
@@ -601,7 +601,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         engine_options["world"]["gravity"] = np.zeros(6)
         engine_options["stepper"]["sensorsUpdatePeriod"] = 0.0
         engine_options["stepper"]["controllerUpdatePeriod"] = 0.0
-        engine_options["stepper"]["logInternalStepperSteps"] = True
+        engine_options["telemetry"]["logInternalStepperSteps"] = True
         engine.set_options(engine_options)
 
         # Run simulation and extract some information from log data
@@ -634,7 +634,7 @@ class SimulateSimplePendulum(unittest.TestCase):
         engine_options["world"]["gravity"] = np.zeros(6)
         engine_options["stepper"]["sensorsUpdatePeriod"] = 0.0
         engine_options["stepper"]["controllerUpdatePeriod"] = 0.0
-        engine_options["stepper"]["logInternalStepperSteps"] = True
+        engine_options["telemetry"]["logInternalStepperSteps"] = True
         engine.set_options(engine_options)
 
         # Configure the engine: Continuous time simulation

--- a/python/jiminy_py/unit_py/test_simulator.py
+++ b/python/jiminy_py/unit_py/test_simulator.py
@@ -66,7 +66,7 @@ class SimulatorTest(unittest.TestCase):
         engine_options["stepper"]["odeSolver"] = "euler_explicit"
         engine_options["stepper"]["dtMax"] = 1e-3
         engine_options["stepper"]["sensorUpdatePeriod"] = 0.0
-        engine_options["stepper"]["logInternalStepperSteps"] = True
+        engine_options["telemetry"]["logInternalStepperSteps"] = True
         engine_options['contacts']['model'] = "constraint"
 
         # Run multiple simulations with different options


### PR DESCRIPTION
* [core] Move 'logInternalStepperSteps' from 'stepper' to 'telemetry' options for consistency.
* [core] Fix rounding error when computing impulse force breakpoints.
* [core] Fix wrong time 't' when computing derivative after successful integration.
* [core] Fix joint jacobian not systematically updated when dealing with external forces.
* [python] Add specialized 'deepcopy' operator for nested data structure.
* [python/robot] Fix default hardware generation.
* [gym_jiminy/common] Plot variables in reverse registeration order.
* [gym_jiminy/common] Jit 'np.mean' for efficiency.
* [gym_jiminy/common] Various minor performance improvements.
* [gym_jiminy/common] Set default (control|observe)_dt in '_setup' instead of 'reset'.
* [gym_jiminy/common] Only register block telemetry variables in debug or evaluation mode.