### PR TITLE
[gym_jiminy/common] Fix quantity computations.

### DIFF
--- a/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
@@ -786,9 +786,11 @@ class AbstractQuantity(InterfaceQuantity, Generic[ValueT]):
         try:
             self.state.initialize()
         except RuntimeError:
-            # No simulation running. This may be problematic but it is not
-            # blocking at this point.
-            pass
+            # It may have failed because no simulation running, which may be
+            # problematic but not blocking at this point. Just checking that
+            # the pinocchio model has been properly initialized.
+            if self.state.pinocchio_model.nq == 0:
+                raise
 
         # Refresh robot proxy
         assert isinstance(self.state, StateQuantity)

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
@@ -292,7 +292,7 @@ class SharedCache(Generic[ValueT]):
                                     Optional: False by default.
         """
         # Clear cache
-        if self.sm_state is _IS_CACHED:
+        if self.sm_state == _IS_CACHED:
             self.sm_state = _IS_INITIALIZED
 
         # Special branch if case quantities must be reset on the way
@@ -320,13 +320,13 @@ class SharedCache(Generic[ValueT]):
         """Return cached value if any, otherwise evaluate it and store it.
         """
         # Get value already stored
-        if self.sm_state is _IS_CACHED:
+        if self.sm_state == _IS_CACHED:
             # return cast(ValueT, self._value)
             return self._value  # type: ignore[return-value]
 
         # Evaluate quantity
         try:
-            if self.sm_state is _IS_RESET:
+            if self.sm_state == _IS_RESET:
                 # Cache the list of owning quantities
                 self.owners = tuple(self._weakrefs)
 
@@ -1179,7 +1179,7 @@ class StateQuantity(InterfaceQuantity[State]):
         # only refresh the state when needed if the evaluation mode is TRAJ.
         # * Update state: 500ns (TRUE) | 5.0us (TRAJ)
         # * Check cache state: 70ns
-        auto_refresh = mode is QuantityEvalMode.TRUE
+        auto_refresh = mode == QuantityEvalMode.TRUE
 
         # Call base implementation.
         super().__init__(
@@ -1189,9 +1189,9 @@ class StateQuantity(InterfaceQuantity[State]):
             auto_refresh=auto_refresh)
 
         # Robot for which the quantity must be evaluated
-        self.robot = env.robot
-        self.pinocchio_model = env.robot.pinocchio_model
-        self.pinocchio_data = env.robot.pinocchio_data
+        self.robot = jiminy.Robot()
+        self.pinocchio_model = self.robot.pinocchio_model
+        self.pinocchio_data = self.robot.pinocchio_data
 
         # State for which the quantity must be evaluated
         self._state = State(t=np.nan, q=np.array([]))
@@ -1326,7 +1326,7 @@ class StateQuantity(InterfaceQuantity[State]):
         """Compute the current state depending on the mode of evaluation, and
         make sure that kinematics and dynamics quantities are up-to-date.
         """
-        if self.mode is _TRUE:
+        if self.mode == _TRUE:
             # Update the current simulation time
             self._state.t = self.env.stepper_state.t
 

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/quantities.py
@@ -601,7 +601,9 @@ class InterfaceQuantity(Generic[ValueT], metaclass=ABCMeta):
                 "Automatic refresh enabled but no shared cache is available. "
                 "Please add one before calling this method.")
 
-        # Reset all requirements first
+        # Reset all requirements first.
+        # This is necessary to avoid auto-refreshing quantities with deprecated
+        # cache if enabled.
         if not ignore_other_instances:
             for quantity in self.requirements.values():
                 quantity.reset(reset_tracking, ignore_other_instances=False)

--- a/python/gym_jiminy/common/gym_jiminy/common/compositions/locomotion.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/compositions/locomotion.py
@@ -136,6 +136,9 @@ class TrackingFootOrientationsReward(TrackingQuantityReward):
     """Reward the agent for tracking the relative orientation of the feet wrt
     each other.
 
+    The error corresponds to the sum of squared total angles of the differences
+    between the true and reference relative orientations for each foot.
+
     .. seealso::
         See `TrackingQuantityReward` documentation for technical details.
     """

--- a/python/gym_jiminy/common/gym_jiminy/common/compositions/mixin.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/compositions/mixin.py
@@ -115,7 +115,7 @@ class AdditiveMixtureReward(MixtureReward):
             raise ValueError(
                 "Exactly one weight per reward component must be specified.")
 
-        # Filter out components whose weight are zero
+        # Filter out components whose weight is zero
         weights, components = zip(*(
             (weight, reward)
             for weight, reward in zip(weights, components)

--- a/python/gym_jiminy/common/gym_jiminy/common/compositions/mixin.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/compositions/mixin.py
@@ -131,7 +131,7 @@ class AdditiveMixtureReward(MixtureReward):
                     "recommended.", reward.name)
                 is_normalized = False
                 break
-            if order == 'inf':
+            if order == float('inf'):
                 scale = max(scale, weight)
             else:
                 scale += weight
@@ -145,7 +145,7 @@ class AdditiveMixtureReward(MixtureReward):
         # Jit-able method computing the weighted sum of reward components
         @nb.jit(nopython=True, cache=True, fastmath=True)
         def weighted_norm(weights: Tuple[float, ...],
-                          order: Union[int, float, Literal['inf']],
+                          order: Union[int, float],
                           values: Tuple[Optional[float], ...]
                           ) -> Optional[float]:
             """Compute the weighted L^p-norm of all the reward components that
@@ -164,10 +164,11 @@ class AdditiveMixtureReward(MixtureReward):
             :returns: Scalar value if at least one of the reward component has
                       been evaluated, `None` otherwise.
             """
+            is_max_norm = order == float('inf')
             total, any_value = 0.0, False
             for value, weight in zip(values, weights):
                 if value is not None:
-                    if isinstance(order, str):
+                    if is_max_norm:
                         if any_value:
                             total = max(total, weight * value)
                         else:
@@ -176,7 +177,7 @@ class AdditiveMixtureReward(MixtureReward):
                         total += weight * math.pow(value, order)
                     any_value = True
             if any_value:
-                if isinstance(order, str):
+                if is_max_norm:
                     return total
                 return math.pow(total, 1.0 / order)
             return None

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/locomotion.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/locomotion.py
@@ -857,11 +857,15 @@ class ZeroMomentPoint(AbstractQuantity[np.ndarray]):
         # Compute the vertical force applied by the robot
         f_z = dhg_linear[2] + self._robot_weight
 
+        # Early return if impossible to compute ZMP (robot is free falling)
+        if abs(f_z) < np.finfo(np.float32).eps:
+            self._zmp[:] = float("nan")
+            return self._zmp
+
         # Compute the ZMP in world frame
         self._zmp[:] = com[:2] * (self._robot_weight / f_z)
-        if abs(f_z) > np.finfo(np.float32).eps:
-            self._zmp[0] -= (dhg_angular[1] + dhg_linear[0] * com[2]) / f_z
-            self._zmp[1] += (dhg_angular[0] - dhg_linear[1] * com[2]) / f_z
+        self._zmp[0] -= (dhg_angular[1] + dhg_linear[0] * com[2]) / f_z
+        self._zmp[1] += (dhg_angular[0] - dhg_linear[1] * com[2]) / f_z
 
         # Translate the ZMP from world to local odometry frame if requested
         if self.reference_frame == pin.LOCAL:

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
@@ -192,8 +192,6 @@ class QuantityManager(MutableMapping):
 
         return top_quantity
 
-        return top_quantity
-
     def __setitem__(self,
                     name: str,
                     quantity_creator: QuantityCreator) -> None:

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
@@ -175,8 +175,17 @@ class QuantityManager(MutableMapping):
                     if quantity == owner:
                         break
             else:
+                # Partially sort cache entries to reset all quantity instances
+                # of the same class at once.
+                # The objective is to avoid resetting multiple times the same
+                # quantity because of the auto-refresh mechanism.
                 cache = SharedCache()
-                self._caches.append((key, cache))
+                for i, (cache_key, _) in enumerate(self._caches):
+                    if key[0] == cache_key[0]:
+                        self._caches.insert(i + 1, (key, cache))
+                        break
+                else:
+                    self._caches.append((key, cache))
 
             # Set shared cache of the quantity
             quantity.cache = cache

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/manager.py
@@ -89,7 +89,6 @@ class QuantityManager(MutableMapping):
         :param reset_tracking: Do not consider any quantity as active anymore.
                                Optional: False by default.
         """
-        # Reset all quantities sequentially
         for quantity in self.registry.values():
             quantity.reset(reset_tracking)
 
@@ -154,12 +153,20 @@ class QuantityManager(MutableMapping):
         quantity_cls, quantity_kwargs = quantity_creator
         top_quantity = quantity_cls(self.env, None, **(quantity_kwargs or {}))
 
-        # Set a shared cache entry for all quantities involved in computations
-        quantities_all = [top_quantity]
+        # Get the list of all quantities involved in computations of the top
+        # level quantity, sorted from highest level to lowest level.
+        quantities_all, quantities_sorted_all = [top_quantity], [top_quantity]
         while quantities_all:
-            # Deal with the first quantity in the process queue
-            quantity = quantities_all.pop()
+            quantities = quantities_all.pop().requirements.values()
+            quantities_all += quantities
+            quantities_sorted_all += quantities
 
+        # Set a shared cache entry for all quantities involved in computations.
+        # Make sure that the cache associated with requirements precedes their
+        # parents in global cache registry. This is essential for automatic
+        # refresh, to ensure that cached values of all the intermediary
+        # quantities have been cleared before refresh.
+        for quantity in quantities_sorted_all[::-1]:
             # Get already available cache entry if any, otherwise create it
             key = (type(quantity), hash(quantity))
             for cache_key, cache in self._caches:
@@ -174,8 +181,7 @@ class QuantityManager(MutableMapping):
             # Set shared cache of the quantity
             quantity.cache = cache
 
-            # Add all the requirements of the new quantity in the process queue
-            quantities_all += quantity.requirements.values()
+        return top_quantity
 
         return top_quantity
 


### PR DESCRIPTION
* [gym_jiminy/common] Fix reliable identity check for enums.
* [gym_jiminy/common] Fix Capture Point quantity initialization messing up with global state.
* [gym_jiminy/common] Fix handling of state initialization failure.
* [gym_jiminy/common] Fix auto-refresh of quantities not working when caching is enabled.
* [gym_jiminy/common] Optimize cache order reset to avoid resetting multiple times the same quantity.
* [gym_jiminy/common] Robust ZMP computation when robot is free falling.