### PR TITLE
[gym_jiminy/common] Fix 'evaluate' total reward computation.

### DIFF
--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -1115,7 +1115,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                  horizon: Optional[int] = None,
                  enable_stats: bool = True,
                  enable_replay: Optional[bool] = None,
-                 **kwargs: Any) -> List[InfoType]:
+                 **kwargs: Any) -> Tuple[List[float], List[InfoType]]:
         r"""Evaluate a policy on the environment over a complete episode.
 
         .. warning::
@@ -1173,7 +1173,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         action, reward, terminated, truncated = None, None, False, False
 
         # Run the simulation
-        total_reward = 0.0
+        reward_episode: List[float] = []
         info_episode = [info]
         try:
             while horizon is None or self.num_steps < horizon:
@@ -1186,7 +1186,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                     break
                 obs, reward, terminated, truncated, info = env.step(action)
                 info_episode.append(info)
-                total_reward += float(reward)
+                reward_episode.append(float(reward))
             env.stop()
         except KeyboardInterrupt:
             pass
@@ -1198,7 +1198,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Display some statistic if requested
         if enable_stats:
             print("env.num_steps:", self.num_steps)
-            print("cumulative reward:", total_reward)
+            print("cumulative reward:", sum(reward_episode))
 
         # Replay the result if requested
         if enable_replay:
@@ -1209,7 +1209,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 traceback = TracebackException.from_exception(e)
                 LOGGER.warning(''.join(traceback.format()))
 
-        return info_episode
+        return reward_episode, info_episode
 
     # methods to override:
     # ----------------------------

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -234,9 +234,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Information about the learning process
         self._info: InfoType = {}
 
-        # Keep track of cumulative reward
-        self.total_reward = 0.0
-
         # Number of simulation steps performed
         self.num_steps = np.array(-1, dtype=np.int64)
         self._num_steps_beyond_terminate: Optional[int] = None
@@ -719,9 +716,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 "The simulation has already terminated at `reset`. Check the "
                 "implementation of `has_terminated` if overloaded.")
 
-        # Reset cumulative reward
-        self.total_reward = 0.0
-
         # Note that the viewer must be reset if available, otherwise it would
         # keep using the old robot model for display, which must be avoided.
         if self.simulator.is_viewer_available:
@@ -858,9 +852,6 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 raise RuntimeError(
                     "The reward is 'nan'. Something went wrong with "
                     "`compute_reward` implementation.")
-
-            # Update cumulative reward
-            self.total_reward += reward
 
         # Clip (and copy) the most derived observation before returning it
         obs = self._get_clipped_env_observation()
@@ -1177,14 +1168,12 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         if is_training:
             self.eval()
 
-        # Set the seed without forcing full reset of the environment
-        self._initialize_seed(seed)
-
         # Initialize the simulation
-        obs, info = env.reset()
+        obs, info = env.reset(seed=seed)
         action, reward, terminated, truncated = None, None, False, False
 
         # Run the simulation
+        total_reward = 0.0
         info_episode = [info]
         try:
             while horizon is None or self.num_steps < horizon:
@@ -1197,6 +1186,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                     break
                 obs, reward, terminated, truncated, info = env.step(action)
                 info_episode.append(info)
+                total_reward += float(reward)
             env.stop()
         except KeyboardInterrupt:
             pass
@@ -1208,7 +1198,7 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Display some statistic if requested
         if enable_stats:
             print("env.num_steps:", self.num_steps)
-            print("cumulative reward:", self.total_reward)
+            print("cumulative reward:", total_reward)
 
         # Replay the result if requested
         if enable_replay:

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -9,6 +9,7 @@ import logging
 import tempfile
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
+from traceback import TracebackException
 from functools import partial
 from typing import (
     Dict, Any, List, cast, no_type_check, Optional, Tuple, Callable, Union,
@@ -1215,7 +1216,8 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 self.replay(**kwargs)
             except Exception as e:  # pylint: disable=broad-except
                 # Do not fail because of replay/recording exception
-                LOGGER.warning("%s", e)
+                traceback = TracebackException.from_exception(e)
+                LOGGER.warning(''.join(traceback.format()))
 
         return info_episode
 

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
@@ -23,6 +23,7 @@ from itertools import chain
 from datetime import datetime
 from collections import defaultdict
 from tempfile import mkdtemp
+from traceback import TracebackException
 from typing import (
     Optional, Any, Union, Sequence, Tuple, List, Literal, Dict, Set, Type,
     DefaultDict, overload, cast)
@@ -825,7 +826,8 @@ def train(algo_config: AlgorithmConfig,
         if verbose or debug:
             print("Interrupting training...")
     except RayTaskError as e:
-        LOGGER.warning("%s", e)
+        traceback = TracebackException.from_exception(e)
+        LOGGER.warning(''.join(traceback.format()))
 
     # Flush and close logger before returning
     if file_writer is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -21,6 +21,7 @@ import tempfile
 import subprocess
 import webbrowser
 import multiprocessing
+from traceback import TracebackException
 from urllib.request import urlopen
 from functools import wraps, partial
 from threading import RLock
@@ -665,7 +666,8 @@ class Viewer:
             except RuntimeError as e:
                 # Convert exception into warning if it fails. It is probably
                 # because no display is available.
-                LOGGER.warning("%s", e)
+                traceback = TracebackException.from_exception(e)
+                LOGGER.warning(''.join(traceback.format()))
         except Exception as e:
             self.close()
             raise RuntimeError(


### PR DESCRIPTION
* [python] Improve exception trackback logging as warning.
* [gym_jiminy/common] Fix 'evaluate' total reward computation.
* [gym_jiminy/common] 'BaseJiminyEnv.evaluate' now returns both reward and info history.