### PR TITLE
[misc] Add support of 'gymnasium==1.0' and 'ray[rllib]==2.40'.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -72,7 +72,7 @@ jobs:
       if: matrix.PYTHON_VERSION != '3.13'
       run: |
         "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.0" "stable_baselines3>=2.0,<2.4"
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy>=1.24" numba torch

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,7 @@ jobs:
       if: matrix.PYTHON_VERSION != '3.13'
       run: |
         "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.0" "stable_baselines3>=2.0,<2.4"
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         if [[ "${{ matrix.BUILD_TYPE }}" != 'Debug' && "${{ matrix.OS }}" != 'macos-13' ]] ; then

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -76,7 +76,7 @@ jobs:
           sudo apt install ninja-build
         fi
         "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.0" "stable_baselines3>=2.0,<2.4"
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
 
     #####################################################################################
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -61,7 +61,7 @@ jobs:
       if: matrix.PYTHON_VERSION != '3.13'
       run: |
         python -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        python -m pip install "gymnasium>=0.28,<1.0" "stable_baselines3>=2.0,<2.4"
+        python -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         python -m pip install --upgrade "numpy>=1.24" numba torch

--- a/core/src/telemetry/telemetry_recorder.cc
+++ b/core/src/telemetry/telemetry_recorder.cc
@@ -363,6 +363,10 @@ namespace jiminy
         {
             JIMINY_THROW(std::ios_base::failure, "Corrupted log file.");
         }
+        if (file.peek() == std::ifstream::traits_type::eof())
+        {
+            JIMINY_THROW(std::invalid_argument, "Empty log file.");
+        }
 
         // Skip the version flag
         int32_t header_version_length = sizeof(int32_t);
@@ -389,12 +393,26 @@ namespace jiminy
         {
         }
 
+        // Make sure that the log file is valid
+        if (headerBuffer.empty())
+        {
+            JIMINY_THROW(std::runtime_error, "Invalid log file.");
+        }
+
         // Extract the number of integers and floats from the list of logged constants
         const std::string & headerNumIntEntries = headerBuffer[headerBuffer.size() - 2];
-        int64_t delimiter = headerNumIntEntries.find(TELEMETRY_CONSTANT_DELIMITER);
+        std::size_t delimiter = headerNumIntEntries.find(TELEMETRY_CONSTANT_DELIMITER);
+        if (delimiter == std::string::npos)
+        {
+            JIMINY_THROW(std::runtime_error, "Invalid log file.");
+        }
         const int32_t NumIntEntries = std::stoi(headerNumIntEntries.substr(delimiter + 1));
         const std::string & headerNumFloatEntries = headerBuffer[headerBuffer.size() - 1];
         delimiter = headerNumFloatEntries.find(TELEMETRY_CONSTANT_DELIMITER);
+        if (delimiter == std::string::npos)
+        {
+            JIMINY_THROW(std::runtime_error, "Invalid log file.");
+        }
         const int32_t NumFloatEntries = std::stoi(headerNumFloatEntries.substr(delimiter + 1));
 
         // Deduce the parameters required to parse the whole binary log file

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/compositions.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/compositions.py
@@ -434,7 +434,7 @@ class AbstractTerminationCondition(metaclass=ABCMeta):
                  grace_period: float = 0.0,
                  *,
                  is_truncation: bool = False,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param name: Desired name of the termination condition. This name will
@@ -451,16 +451,16 @@ class AbstractTerminationCondition(metaclass=ABCMeta):
                               terminated or truncated whenever the termination
                               condition is triggered.
                               Optional: False by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         self.env = env
         self._name = name
         self.grace_period = grace_period
         self.is_truncation = is_truncation
-        self.is_training_only = is_training_only
+        self.training_only = training_only
 
     @property
     def name(self) -> str:
@@ -505,7 +505,7 @@ class AbstractTerminationCondition(metaclass=ABCMeta):
         """
         # Skip termination condition in eval mode or during grace period
         termination_info: InfoType = {}
-        if (self.is_training_only and not self.env.is_training) or (
+        if (self.training_only and not self.env.training) or (
                 self.env.stepper_state.t < self.grace_period):
             # Always continue
             is_terminated, is_truncated = False, False
@@ -555,7 +555,7 @@ class QuantityTermination(AbstractTerminationCondition, Generic[ValueT]):
                  grace_period: float = 0.0,
                  *,
                  is_truncation: bool = False,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param name: Desired name of the termination condition. This name will
@@ -578,10 +578,10 @@ class QuantityTermination(AbstractTerminationCondition, Generic[ValueT]):
                               terminated or truncated whenever the termination
                               condition is triggered.
                               Optional: False by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # Backup user argument(s)
         self.low = np.asarray(low) if isinstance(low, Sequence) else low
@@ -593,7 +593,7 @@ class QuantityTermination(AbstractTerminationCondition, Generic[ValueT]):
             name,
             grace_period,
             is_truncation=is_truncation,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
         # Add quantity to the set of quantities managed by the environment
         self.env.quantities[self.name] = quantity

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
@@ -410,11 +410,13 @@ class InterfaceJiminyEnv(
         """
 
     @abstractmethod
-    def train(self) -> None:
-        """Sets the environment in training mode.
+    def train(self, mode: bool = True) -> None:
+        """Sets the environment in training or evaluation mode.
+
+        :param mode: Whether to set training (True) or evaluation mode (False).
+                     Optional: `True` by default.
         """
 
-    @abstractmethod
     def eval(self) -> None:
         """Sets the environment in evaluation mode.
 
@@ -423,6 +425,19 @@ class InterfaceJiminyEnv(
         time specifically. See documentations of a given environment for
         details about their behaviors in training and evaluation modes.
         """
+        self.train(False)
+
+    @property
+    @abstractmethod
+    def training(self) -> bool:
+        """Check whether the environment is in training or evaluation mode.
+        """
+
+    @training.setter
+    def training(self, mode: bool) -> None:
+        """Sets the environment in training or evaluation mode.
+        """
+        self.train(mode)
 
     @property
     @abstractmethod
@@ -435,10 +450,4 @@ class InterfaceJiminyEnv(
     @abstractmethod
     def step_dt(self) -> float:
         """Get timestep of a single 'step'.
-        """
-
-    @property
-    @abstractmethod
-    def is_training(self) -> bool:
-        """Check whether the environment is in 'train' or 'eval' mode.
         """

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -294,9 +294,13 @@ class BasePipelineWrapper(
     def step_dt(self) -> float:
         return self.env.step_dt
 
-    @InterfaceJiminyEnv.training.getter  # type: ignore[attr-defined]
+    @property
     def training(self) -> bool:
-        return self.env.training
+        return self._is_training
+
+    @training.setter
+    def training(self, mode: bool) -> None:
+        self.env.train(mode)
 
     def train(self, mode: bool = True) -> None:
         self.env.train(mode)

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -143,7 +143,7 @@ def _merge_base_env_with_block(
             assert issubclass_mapping(type(base_group))
             base_group[block_name] = block_group  # type: ignore[index]
 
-    return mapping_cls(observation)  # type: ignore[call-arg]
+    return mapping_cls(**observation)
 
 
 class BasePipelineWrapper(

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -658,7 +658,8 @@ class ComposedJiminyEnv(BasePipelineWrapper[Obs, Act, Obs, Act],
                     high=float("inf"),
                     shape=(length_lambda_c,),
                     dtype=np.float64)
-            trajectory_space = gym.spaces.Dict(state_space)
+            trajectory_space = gym.spaces.Dict(
+                **state_space)  # type: ignore[arg-type]
 
         # Aggregate the reference trajectory space with the base observation
         self.observation_space = cast(

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/pipeline.py
@@ -222,7 +222,7 @@ class BasePipelineWrapper(
         try:
             # Make sure that no simulaton is running
             if (self.__getattribute__('is_simulation_running') and
-                    self.env.is_training and not hasattr(sys, 'ps1')):
+                    self.env.training and not hasattr(sys, 'ps1')):
                 # `hasattr(sys, 'ps1')` is used to detect whether the method
                 # was called from an interpreter or within a script. For
                 # details, see: https://stackoverflow.com/a/64523765/4820605
@@ -294,15 +294,12 @@ class BasePipelineWrapper(
     def step_dt(self) -> float:
         return self.env.step_dt
 
-    @property
-    def is_training(self) -> bool:
-        return self.env.is_training
+    @InterfaceJiminyEnv.training.getter  # type: ignore[attr-defined]
+    def training(self) -> bool:
+        return self.env.training
 
-    def train(self) -> None:
-        self.env.train()
-
-    def eval(self) -> None:
-        self.env.eval()
+    def train(self, mode: bool = True) -> None:
+        self.env.train(mode)
 
     def update_pipeline(self, derived: Optional[InterfaceJiminyEnv]) -> None:
         if derived is None:

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/body_orientation_observer.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/body_orientation_observer.py
@@ -205,7 +205,8 @@ class BodyObserver(BaseObserverBlock[
             high=float('inf'),
             shape=(3, num_imu_sensors),
             dtype=np.float64)
-        self.observation_space = gym.spaces.Dict(observation_space)
+        self.observation_space = gym.spaces.Dict(
+            **observation_space)  # type: ignore[arg-type]
 
     def _setup(self) -> None:
         # Call base implementation

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/deformation_estimator.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/deformation_estimator.py
@@ -746,7 +746,8 @@ class DeformationEstimator(BaseObserverBlock[
                 low=-high[:, np.newaxis].repeat(nflex, axis=1),
                 high=high[:, np.newaxis].repeat(nflex, axis=1),
                 dtype=np.float64)
-        self.observation_space = gym.spaces.Dict(observation_space)
+        self.observation_space = gym.spaces.Dict(
+            **observation_space)  # type: ignore[arg-type]
 
     def _setup(self) -> None:
         # Call base implementation

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/mahony_filter.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/mahony_filter.py
@@ -241,7 +241,8 @@ class MahonyFilter(BaseObserverBlock[
             low=np.full((3, num_imu_sensors), -np.inf),
             high=np.full((3, num_imu_sensors), np.inf),
             dtype=np.float64)
-        self.state_space = gym.spaces.Dict(state_space)
+        self.state_space = gym.spaces.Dict(
+            **state_space)  # type: ignore[arg-type]
 
     def _initialize_observation_space(self) -> None:
         """Configure the observation space of the observer.
@@ -271,7 +272,8 @@ class MahonyFilter(BaseObserverBlock[
             high=float('inf'),
             shape=(3, num_imu_sensors),
             dtype=np.float64)
-        self.observation_space = gym.spaces.Dict(observation_space)
+        self.observation_space = gym.spaces.Dict(
+            **observation_space)  # type: ignore[arg-type]
 
     def _setup(self) -> None:
         # Call base implementation

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/motor_safety_limit.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/motor_safety_limit.py
@@ -219,7 +219,7 @@ class MotorSafetyLimit(
 
         # Unbounded effort limits in evaluation mode.
         # Note that training/evaluation cannot be changed at this point.
-        self._enable_limit_soft = self.env.is_training
+        self._enable_limit_soft = self.env.training
 
     def compute_command(self,
                         action: np.ndarray,

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/proportional_derivative_controller.py
@@ -488,7 +488,7 @@ class PDController(
 
         # Enable deadband in evaluation mode only.
         # Note that training/evaluation cannot be changed at this point.
-        self._enable_deadband = not self.env.is_training
+        self._enable_deadband = not self.env.training
 
     @property
     def fieldnames(self) -> List[str]:

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/quantity_observer.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/quantity_observer.py
@@ -1,7 +1,6 @@
 """Implementation of Mahony filter block compatible with gym_jiminy
 reinforcement learning pipeline environment design.
 """
-from collections import OrderedDict
 from typing import Any, Type, TypeVar, cast
 
 import numpy as np

--- a/python/gym_jiminy/common/gym_jiminy/common/blocks/quantity_observer.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/blocks/quantity_observer.py
@@ -32,9 +32,9 @@ def get_space(data: DataNested) -> gym.Space[DataNested]:
     """
     data_type = type(data)
     if tree.issubclass_mapping(data_type):
-        return gym.spaces.Dict(OrderedDict([
+        return gym.spaces.Dict([
             (field, get_space(value))
-            for field, value in data.items()]))  # type: ignore[union-attr]
+            for field, value in data.items()])  # type: ignore[union-attr]
     if tree.issubclass_sequence(data_type):
         return gym.spaces.Tuple([get_space(value) for value in data])
     assert isinstance(data, np.ndarray)

--- a/python/gym_jiminy/common/gym_jiminy/common/compositions/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/compositions/generic.py
@@ -176,7 +176,7 @@ class DriftTrackingQuantityTermination(QuantityTermination):
                  post_fn: Optional[Callable[
                     [ArrayOrScalar], ArrayOrScalar]] = None,
                  is_truncation: bool = False,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param name: Desired name of the termination condition. This name will
@@ -214,10 +214,10 @@ class DriftTrackingQuantityTermination(QuantityTermination):
                               terminated or truncated whenever the termination
                               condition is triggered.
                               Optional: False by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # pylint: disable=unnecessary-lambda-assignment
 
@@ -256,7 +256,7 @@ class DriftTrackingQuantityTermination(QuantityTermination):
                          high,
                          grace_period,
                          is_truncation=is_truncation,
-                         is_training_only=is_training_only)
+                         training_only=training_only)
 
     def _compute_drift_error(self,
                              left: np.ndarray,
@@ -298,7 +298,7 @@ class ShiftTrackingQuantityTermination(QuantityTermination[np.ndarray]):
                  *,
                  op: Callable[[np.ndarray, np.ndarray], np.ndarray] = sub,
                  is_truncation: bool = False,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param name: Desired name of the termination condition. This name will
@@ -335,10 +335,10 @@ class ShiftTrackingQuantityTermination(QuantityTermination[np.ndarray]):
                               terminated or truncated whenever the termination
                               condition is triggered.
                               Optional: False by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # pylint: disable=unnecessary-lambda-assignment
 
@@ -388,7 +388,7 @@ class ShiftTrackingQuantityTermination(QuantityTermination[np.ndarray]):
                          np.array(thr),
                          max(grace_period, horizon),
                          is_truncation=is_truncation,
-                         is_training_only=is_training_only)
+                         training_only=training_only)
 
     def _compute_min_distance(self,
                               left: np.ndarray,
@@ -483,7 +483,7 @@ class MechanicalSafetyTermination(AbstractTerminationCondition):
                  velocity_max: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param position_margin: Distance of actuated joints from their
@@ -496,10 +496,10 @@ class MechanicalSafetyTermination(AbstractTerminationCondition):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # Backup user argument(s)
         self.position_margin = position_margin
@@ -511,7 +511,7 @@ class MechanicalSafetyTermination(AbstractTerminationCondition):
             "termination_mechanical_safety",
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
         # Add quantity to the set of quantities managed by the environment
         self.env.quantities["_".join((self.name, "position_delta"))] = (
@@ -577,7 +577,7 @@ class MechanicalPowerConsumptionTermination(QuantityTermination):
             generator_mode: EnergyGenerationMode = EnergyGenerationMode.CHARGE,
             grace_period: float = 0.0,
             *,
-            is_training_only: bool = False) -> None:
+            training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_power: Maximum average mechanical power consumption applied
@@ -589,10 +589,10 @@ class MechanicalPowerConsumptionTermination(QuantityTermination):
                              Optional: 0.0 by default.
         :param horizon: Horizon over which values of the quantity will be
                         stacked before computing the average.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # Backup user argument(s)
         self.max_power = max_power
@@ -610,7 +610,7 @@ class MechanicalPowerConsumptionTermination(QuantityTermination):
             self.max_power,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class ShiftTrackingMotorPositionsTermination(ShiftTrackingQuantityTermination):
@@ -638,7 +638,7 @@ class ShiftTrackingMotorPositionsTermination(ShiftTrackingQuantityTermination):
                  horizon: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param thr: Maximum shift above which termination is triggered.
@@ -648,10 +648,10 @@ class ShiftTrackingMotorPositionsTermination(ShiftTrackingQuantityTermination):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # Call base implementation
         super().__init__(
@@ -665,4 +665,4 @@ class ShiftTrackingMotorPositionsTermination(ShiftTrackingQuantityTermination):
             horizon,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)

--- a/python/gym_jiminy/common/gym_jiminy/common/compositions/locomotion.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/compositions/locomotion.py
@@ -281,7 +281,7 @@ class BaseRollPitchTermination(QuantityTermination):
                  high: Optional[ArrayLikeOrScalar],
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param low: Lower bound below which termination is triggered.
@@ -290,10 +290,10 @@ class BaseRollPitchTermination(QuantityTermination):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -308,7 +308,7 @@ class BaseRollPitchTermination(QuantityTermination):
             high,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class FallingTermination(QuantityTermination):
@@ -328,7 +328,7 @@ class FallingTermination(QuantityTermination):
                  min_base_height: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param min_base_height: Minimum height of the floating base of the
@@ -337,10 +337,10 @@ class FallingTermination(QuantityTermination):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -350,7 +350,7 @@ class FallingTermination(QuantityTermination):
             None,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class FootCollisionTermination(QuantityTermination):
@@ -367,7 +367,7 @@ class FootCollisionTermination(QuantityTermination):
                  grace_period: float = 0.0,
                  frame_names: Union[Sequence[str], Literal['auto']] = 'auto',
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param security_margin:
@@ -383,10 +383,10 @@ class FootCollisionTermination(QuantityTermination):
                             robot. 'auto' to automatically detect them from the
                             set of contact and force sensors of the robot.
                             Optional: 'auto' by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -398,7 +398,7 @@ class FootCollisionTermination(QuantityTermination):
             False,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 @dataclass(unsafe_hash=True)
@@ -511,7 +511,7 @@ class FlyingTermination(QuantityTermination):
                  max_height: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_height: Maximum height of the lowest contact points wrt the
@@ -520,10 +520,10 @@ class FlyingTermination(QuantityTermination):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -533,7 +533,7 @@ class FlyingTermination(QuantityTermination):
             max_height,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class ImpactForceTermination(QuantityTermination):
@@ -548,7 +548,7 @@ class ImpactForceTermination(QuantityTermination):
                  max_force_rel: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_force_rel: Maximum vertical force applied on any of the
@@ -558,10 +558,10 @@ class ImpactForceTermination(QuantityTermination):
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -574,7 +574,7 @@ class ImpactForceTermination(QuantityTermination):
             max_force_rel,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 @nb.jit(nopython=True, cache=True, fastmath=True, inline='always')
@@ -617,7 +617,7 @@ class DriftTrackingBaseOdometryPositionTermination(
                  horizon: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_position_err:
@@ -629,10 +629,10 @@ class DriftTrackingBaseOdometryPositionTermination(
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -649,7 +649,7 @@ class DriftTrackingBaseOdometryPositionTermination(
             grace_period,
             post_fn=l2_norm,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class DriftTrackingBaseOdometryOrientationTermination(
@@ -666,7 +666,7 @@ class DriftTrackingBaseOdometryOrientationTermination(
                  horizon: float,
                  grace_period: float = 0.0,
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_orientation_err:
@@ -678,10 +678,10 @@ class DriftTrackingBaseOdometryOrientationTermination(
                              of the episode, during which the latter is bound
                              to continue whatever happens.
                              Optional: 0.0 by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -697,7 +697,7 @@ class DriftTrackingBaseOdometryOrientationTermination(
             horizon,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class ShiftTrackingFootOdometryPositionsTermination(
@@ -717,7 +717,7 @@ class ShiftTrackingFootOdometryPositionsTermination(
                  grace_period: float = 0.0,
                  frame_names: Union[Sequence[str], Literal['auto']] = 'auto',
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
         :param max_position_err:
@@ -733,10 +733,10 @@ class ShiftTrackingFootOdometryPositionsTermination(
                             robot. 'auto' to automatically detect them from the
                             set of contact and force sensors of the robot.
                             Optional: 'auto' by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         super().__init__(
             env,
@@ -752,7 +752,7 @@ class ShiftTrackingFootOdometryPositionsTermination(
             horizon,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)
 
 
 class ShiftTrackingFootOdometryOrientationsTermination(
@@ -772,7 +772,7 @@ class ShiftTrackingFootOdometryOrientationsTermination(
                  grace_period: float = 0.0,
                  frame_names: Union[Sequence[str], Literal['auto']] = 'auto',
                  *,
-                 is_training_only: bool = False) -> None:
+                 training_only: bool = False) -> None:
         """
         :param env: Base or wrapped jiminy environment.
             Maximum shift error in orientation (yaw,) in world plane above
@@ -787,10 +787,10 @@ class ShiftTrackingFootOdometryOrientationsTermination(
                             robot. 'auto' to automatically detect them from the
                             set of contact and force sensors of the robot.
                             Optional: 'auto' by default.
-        :param is_training_only: Whether the termination condition should be
-                                 completely by-passed if the environment is in
-                                 evaluation mode.
-                                 Optional: False by default.
+        :param training_only: Whether the termination condition should be
+                              completely by-passed if the environment is in
+                              evaluation mode.
+                              Optional: False by default.
         """
         # Call base implementation
         super().__init__(
@@ -808,4 +808,4 @@ class ShiftTrackingFootOdometryOrientationsTermination(
             horizon,
             grace_period,
             is_truncation=False,
-            is_training_only=is_training_only)
+            training_only=training_only)

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -286,10 +286,10 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             # Note that time is removed from the observation space because it
             # will be checked independently.
             assert isinstance(reduced_obs_space, spaces.Dict)
-            reduced_obs_space = spaces.Dict(OrderedDict(
+            reduced_obs_space = spaces.Dict([
                 (key, value)
                 for key, value in reduced_obs_space.items()
-                if key != 't'))
+                if key != 't'])
         self._contains_observation = build_contains(
             self.observation, reduced_obs_space, tol_rel=OBS_CONTAINS_TOL)
         self._get_clipped_env_observation: Callable[[], DataNested] = (
@@ -1309,8 +1309,8 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
             spaces.Dict(agent=get_robot_state_space(self.robot)))
         observation_spaces['measurements'] = (
             get_robot_measurements_space(self.robot))
-        self.observation_space = cast(
-            spaces.Space[Obs], spaces.Dict(observation_spaces))
+        self.observation_space = cast(spaces.Space[Obs], spaces.Dict(
+            **observation_spaces))  # type: ignore[arg-type]
 
     def _neutral(self) -> np.ndarray:
         """Returns a neutral valid configuration for the agent.

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -1430,7 +1430,6 @@ def build_flatten(data_nested: DataNested,
     @nb.jit(nopython=True, cache=True, fastmath=True)
     def _flatten_nd(data: np.ndarray,
                     idx_start: int,
-                    idx_end: int,
                     data_flat: np.ndarray,
                     is_fortran: bool,
                     is_reversed: bool) -> None:
@@ -1442,7 +1441,8 @@ def build_flatten(data_nested: DataNested,
 
         :param data: Multi-dimensional array that will be either updated or
                      copied as a whole depending on 'is_reversed'.
-        :param idx_slice: Slice of 'data_flat' to synchronized with 'data'.
+        :param idx_start: First index of the slice of 'data_flat' to
+                          synchronized with 'data'.
         :param data_flat: 1D array from which to extract that will be either
                           updated or copied depending on 'is_reversed'.
         :param is_fortran: Order in which the elements of multi-dimensional
@@ -1513,8 +1513,7 @@ def build_flatten(data_nested: DataNested,
             return
 
         # General case looping over each element individually
-        _flatten_nd(
-            data, idx_start, idx_end, data_flat, is_fortran, is_reversed)
+        _flatten_nd(data, idx_start, data_flat, is_fortran, is_reversed)
 
     args = (order == 'F', is_reversed)
     if data_flat is not None:

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -145,14 +145,14 @@ def get_robot_state_space(robot: jiminy.Robot,
         velocity_limit = np.full_like(velocity_limit, float("inf"))
 
     # Aggregate position and velocity bounds to define state space
-    return gym.spaces.Dict(OrderedDict(
+    return gym.spaces.Dict(
         q=gym.spaces.Box(low=position_limit_lower,
                          high=position_limit_upper,
                          dtype=np.float64),
         v=gym.spaces.Box(low=float("-inf"),
                          high=float("inf"),
                          shape=(robot.pinocchio_model.nv,),
-                         dtype=np.float64)))
+                         dtype=np.float64))
 
 
 def get_robot_measurements_space(robot: jiminy.Robot) -> gym.spaces.Dict:
@@ -231,10 +231,10 @@ def get_robot_measurements_space(robot: jiminy.Robot) -> gym.spaces.Dict:
         sensor_space_upper[EffortSensor.type][0, sensor.index] = (
             motor.effort_limit)
 
-    return gym.spaces.Dict(OrderedDict(
+    return gym.spaces.Dict([
         (key, gym.spaces.Box(low=min_val, high=max_val, dtype=np.float64))
         for (key, min_val), max_val in zip(
-            sensor_space_lower.items(), sensor_space_upper.values())))
+            sensor_space_lower.items(), sensor_space_upper.values())])
 
 
 def get_bounds(space: gym.Space,

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/spaces.py
@@ -1378,7 +1378,9 @@ def build_normalize(space: gym.Space[DataNested],
 
 def build_flatten(data_nested: DataNested,
                   data_flat: Optional[DataNested] = None,
-                  *, is_reversed: Optional[bool] = None
+                  *,
+                  order: Literal['C', 'F'] = 'C',
+                  is_reversed: Optional[bool] = None
                   ) -> Callable[..., None]:
     """Generate a flattening or un-flattening method specialized for some
     pre-allocated nested data.
@@ -1393,6 +1395,10 @@ def build_flatten(data_nested: DataNested,
     :param data_flat: Flat array consistent with the nested data structure.
                       Optional iif `is_reversed` is `True`.
                       Optional: `None` by default.
+    :param order: Order in which the elements of multi-dimensional arrays are
+                  sorted into the flattened vector. See 'numpy.ravel'
+                  documentation for details. Only 'C' and 'F' are supported.
+                  Optiona: 'C' by default.
     :param is_reversed: True to update 'data_flat' (flattening), 'data_nested'
                         otherwise (un-flattening).
                         Optional: True if 'data_flat' is specified, False
@@ -1402,6 +1408,8 @@ def build_flatten(data_nested: DataNested,
     if is_reversed is None:
         is_reversed = data_flat is None
     assert is_reversed or data_flat is not None
+    if order not in ('C', 'F'):
+        raise ValueError("Order must be 'C' or 'F'.")
 
     # Flatten nested data while preserving leaves ordering
     data_leaves = tree.flatten(data_nested)
@@ -1419,11 +1427,62 @@ def build_flatten(data_nested: DataNested,
         stop_indices.append(idx_end)
         idx_start = idx_end
 
-    @nb.jit(nopython=True, cache=True)
+    @nb.jit(nopython=True, cache=True, fastmath=True)
+    def _flatten_nd(data: np.ndarray,
+                    idx_start: int,
+                    idx_end: int,
+                    data_flat: np.ndarray,
+                    is_fortran: bool,
+                    is_reversed: bool) -> None:
+        """Synchronize the flatten and un-flatten representation of the data
+        associated with the same leaf space.
+
+        Generic implementation flattening multi-dimensional arrays by copying
+        from source to destination element-by-element without vectorization.
+
+        :param data: Multi-dimensional array that will be either updated or
+                     copied as a whole depending on 'is_reversed'.
+        :param idx_slice: Slice of 'data_flat' to synchronized with 'data'.
+        :param data_flat: 1D array from which to extract that will be either
+                          updated or copied depending on 'is_reversed'.
+        :param is_fortran: Order in which the elements of multi-dimensional
+                           arrays are sorted into the flattened vector.
+        :param is_reversed: True to update the multi-dimensional array 'data'
+                            by copying the value from slice 'flat_slice' of
+                            vector 'data_flat', False for doing the contrary.
+        """
+        # Note that passing string or slices as input argument is very slow
+        # in numba. Moreover, assignment does not appear to be vectorized, so
+        # looping element-by-element should be equally fast than directly
+        # assigning the whole flattened view of ND-array whenever possible.
+        if is_reversed:
+            if is_fortran:
+                idx = idx_start
+                for multi_index in np.ndindex(data.T.shape):
+                    data[multi_index[::-1]] = data_flat[idx]
+                    idx += 1
+            else:
+                idx = idx_start
+                for multi_index in np.ndindex(data.shape):
+                    data[multi_index] = data_flat[idx]
+                    idx += 1
+        else:
+            if is_fortran:
+                idx = idx_start
+                for multi_index in np.ndindex(data.T.shape):
+                    data_flat[idx] = data[multi_index[::-1]]
+                    idx += 1
+            else:
+                idx = idx_start
+                for multi_index in np.ndindex(data.shape):
+                    data_flat[idx] = data[multi_index]
+                    idx += 1
+
     def _flatten(data: np.ndarray,
                  idx_start: int,
                  idx_end: int,
                  data_flat: np.ndarray,
+                 is_fortran: bool,
                  is_reversed: bool) -> None:
         """Synchronize the flatten and un-flatten representation of the data
         associated with the same leaf space.
@@ -1439,20 +1498,28 @@ def build_flatten(data_nested: DataNested,
                         synchronized with 'data'.
         :param data_flat: 1D array from which to extract that will be either
                           updated or copied depending on 'is_reversed'.
+        :param is_fortran: Order in which the elements of multi-dimensional
+                           arrays are sorted into the flattened vector.
         :param is_reversed: True to update the multi-dimensional array 'data'
                             by copying the value from slice 'flat_slice' of
                             vector 'data_flat', False for doing the contrary.
         """
-        # Note that passing slices as input argument is very slow in numba
-        if is_reversed:
-            data.ravel()[:] = data_flat[idx_start:idx_end]
-        else:
-            data_flat[idx_start:idx_end] = data.ravel()
+        # Deal with special cases allowing fast vectorized implementation
+        if data.ndim == 1:
+            if is_reversed:
+                array_copyto(data, data_flat[idx_start:idx_end])
+            else:
+                array_copyto(data_flat[idx_start:idx_end], data)
+            return
 
-    args = (is_reversed,)
+        # General case looping over each element individually
+        _flatten_nd(
+            data, idx_start, idx_end, data_flat, is_fortran, is_reversed)
+
+    args = (order == 'F', is_reversed)
     if data_flat is not None:
         args = (data_flat, *args)  # type: ignore[assignment]
-    arity = 2 - len(args)
+    arity = 3 - len(args)
     out_fn = build_reduce(_flatten, None, (
         data_leaves, start_indices, stop_indices), None, arity, *args)
     if data_flat is None:

--- a/python/gym_jiminy/common/setup.py
+++ b/python/gym_jiminy/common/setup.py
@@ -54,10 +54,9 @@ setup(
         # - 0.56: Adds 'np.broadcast_shapes'
         "numba>=0.56.0",
         # Standard interface library for reinforcement learning.
-        # - `gym` has been replaced by `gymnasium` for 0.26.0+
         # - 0.28.0: fully typed
         # - bound version for resilience to recurrent API breakage
-        "gymnasium>=0.28,<1.0",
+        "gymnasium>=0.28,<=1.0",
         # For backward compatibility of latest Python typing features
         # - 'Unpack' was introduced with Python 3.11
         "typing_extensions>=4.1.0",

--- a/python/gym_jiminy/common/setup.py
+++ b/python/gym_jiminy/common/setup.py
@@ -56,7 +56,7 @@ setup(
         # Standard interface library for reinforcement learning.
         # - 0.28.0: fully typed
         # - bound version for resilience to recurrent API breakage
-        "gymnasium>=0.28,<=1.0",
+        "gymnasium>=0.28,<1.1",
         # For backward compatibility of latest Python typing features
         # - 'Unpack' was introduced with Python 3.11
         "typing_extensions>=4.1.0",

--- a/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
+++ b/python/gym_jiminy/envs/gym_jiminy/envs/acrobot.py
@@ -159,8 +159,6 @@ class AcrobotJiminyEnv(BaseJiminyEnv[np.ndarray, np.ndarray]):
             low=np.concatenate((position_space.low, velocity_space.low)),
             high=np.concatenate((position_space.high, velocity_space.high)),
             dtype=np.float64)
-        self.observation_space.mirror_mat = (  # type: ignore[attr-defined]
-            np.diag([1.0, -1.0, 1.0, -1.0, -1.0, -1.0]))
 
     def refresh_observation(self, measurement: EngineObsType) -> None:
         angles, velocities = measurement['measurements']['EncoderSensor']
@@ -180,8 +178,6 @@ class AcrobotJiminyEnv(BaseJiminyEnv[np.ndarray, np.ndarray]):
                 gym.spaces.Discrete(len(self.AVAIL_CTRL)))
         else:
             super()._initialize_action_space()
-            self.action_space.mirror_mat = (  # type: ignore[attr-defined]
-                - np.eye(1))
 
     def _sample_state(self) -> Tuple[np.ndarray, np.ndarray]:
         """Returns a valid configuration and velocity for the robot.

--- a/python/gym_jiminy/examples/rllib/acrobot_ppo.py
+++ b/python/gym_jiminy/examples/rllib/acrobot_ppo.py
@@ -12,6 +12,7 @@ It solves it consistently in less than 100000 timesteps in average.
 import os
 from copy import deepcopy
 
+import numpy as np
 import gymnasium as gym
 
 import ray
@@ -38,18 +39,22 @@ ENABLE_VIEWER = "JIMINY_VIEWER_DISABLE" not in os.environ
 DEBUG = False
 SEED = 0
 N_THREADS = 9
-N_GPU = 0
+N_GPUS = 0
 
 if __name__ == "__main__":
     # ==================== Initialize Ray and Tensorboard =====================
 
     # Start Ray and Tensorboard background processes
     logdir = initialize(
-        num_cpus=N_THREADS, num_gpus=N_GPU, debug=DEBUG, verbose=True)
+        num_cpus=N_THREADS, num_gpus=N_GPUS, debug=DEBUG, verbose=True)
 
     # Register the environment
     env_creator = lambda env_config: gym.make(GYM_ENV_NAME, **env_config)
     register_env("env", env_creator)
+
+    # Mirroring map along X-axis
+    obs_mirror_mat = np.diag([1.0, -1.0, 1.0, -1.0, -1.0, -1.0])
+    action_mirror_mat = np.diag([-1.0])
 
     # ========================== Configure resources ==========================
 
@@ -64,16 +69,16 @@ if __name__ == "__main__":
         num_gpus_per_env_runner=0,
     )
     algo_config.learners(
-        # Number of Learner workers used for updating the policy
-        num_learners=N_GPU if N_GPU > 1 else 0,
-        # Number of CPUs allocated per Learner worker
+        # Number of learner workers used for updating the policy
+        num_learners=N_GPUS if N_GPUS > 1 else 0,
+        # Number of CPUs allocated per learner worker
         num_cpus_per_learner=1,
-        # Number of GPUs allocated per Learner worker
-        num_gpus_per_learner=min(1, N_GPU),
+        # Number of GPUs allocated per learner worker
+        num_gpus_per_learner=min(1, N_GPUS),
     )
     algo_config.env_runners(
         # Number of rollout worker processes for parallel sampling
-        num_env_runners=N_THREADS-1,
+        num_env_runners=N_THREADS - 1,
         # Number of environments per worker processes
         num_envs_per_env_runner=1,
     )
@@ -83,7 +88,7 @@ if __name__ == "__main__":
     # Debugging and monitoring settings
     algo_config.fault_tolerance(
         # Whether to attempt to continue training if a worker crashes
-        recreate_failed_env_runners=False
+        restart_failed_env_runners=False
     )
     algo_config.debugging(
         # Set the log level for the whole learning process
@@ -108,9 +113,9 @@ if __name__ == "__main__":
         # The unit with which to count the evaluation duration
         evaluation_duration_unit="episodes",
         # Number of parallel workers to use for evaluation
-        evaluation_num_env_runners=1,         # TODO: 0
+        evaluation_num_env_runners=1,
         # Whether to run evaluation in parallel to a Algorithm.train()
-        evaluation_parallel_to_training=True  # TODO: Try false
+        evaluation_parallel_to_training=True
     )
 
     # =========================== Configure rollout ===========================
@@ -155,7 +160,7 @@ if __name__ == "__main__":
     # Batch settings settings
     algo_config.training(
         # Sample batches are concatenated together into batches of this size
-        train_batch_size_per_learner=2000/max(1, N_GPU),
+        train_batch_size_per_learner=2000/max(1, N_GPUS),
         # Learning rate
         lr=5.0e-4,
         # Discount factor of the MDP (0.991: ~1% after 500 step)
@@ -196,6 +201,7 @@ if __name__ == "__main__":
         temporal_barrier_threshold=6.0,
         temporal_barrier_reg=1.0,
         symmetric_policy_reg=0.1,
+        symmetric_spec=(obs_mirror_mat, action_mirror_mat),
         enable_symmetry_surrogate_loss=False,
         caps_temporal_reg=0.005,
         caps_spatial_reg=0.1,
@@ -272,7 +278,7 @@ if __name__ == "__main__":
     rl_module = build_module_from_checkpoint(checkpoint_path)
     policy_fn = build_module_wrapper(rl_module)
     for seed in (1, 1, 2):
-        env.evaluate(  # type: ignore[attr-defined]
+        env.get_wrapper_attr("evaluate")(
             policy_fn,
             seed=seed,
             horizon=env.spec.max_episode_steps)  # type: ignore[union-attr]

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/curriculum.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/curriculum.py
@@ -87,7 +87,7 @@ def build_task_scheduling_callback(history_length: int,
                                    *,
                                    env_runner: EnvRunner,
                                    metrics_logger: MetricsLogger,
-                                   env: gym.Env,
+                                   env: gym.vector.VectorEnv,
                                    env_context: EnvContext,
                                    **kwargs: Any) -> None:
             # Early return if the callback is already initialized
@@ -256,7 +256,7 @@ def build_task_scheduling_callback(history_length: int,
                 assert isinstance(env_runner, SingleAgentEnvRunner)
                 env = env_runner.env.unwrapped
                 assert isinstance(env, gym.vector.SyncVectorEnv)
-                for env in env.envs:
+                for env in env.unwrapped.envs:
                     while not isinstance(env, TaskSchedulingWrapper):
                         assert isinstance(
                             env, (gym.Wrapper, BasePipelineWrapper))

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
@@ -892,7 +892,7 @@ def _sample_initialize(worker: EnvRunner) -> Sequence[bool]:
     worker.env.unwrapped.call('stop')
 
     # Switch the environment to evaluation mode
-    is_training_all = worker.env.unwrapped.get_attr('is_training')
+    is_training_all = worker.env.unwrapped.get_attr('training')
     worker.env.unwrapped.call('eval')
 
     return is_training_all
@@ -967,13 +967,12 @@ def _sample_finalize(worker: EnvRunner,
 
     # Restore the original training/evaluation mode
     if parse_version(gym.__version__) >= parse_version("1.0"):
-        worker.env.unwrapped.set_attr('is_training', is_training_all)
+        worker.env.unwrapped.set_attr('training', is_training_all)
     else:
         assert isinstance(worker.env.unwrapped, gym.vector.SyncVectorEnv)
         for env, is_training in zip(
                 worker.env.unwrapped.envs, is_training_all):
-            if is_training:
-                env.get_wrapper_attr("train")()
+            env.get_wrapper_attr("train")(is_training)
 
 
 def sample_from_runner(

--- a/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
+++ b/python/gym_jiminy/rllib/gym_jiminy/rllib/utilities.py
@@ -81,8 +81,8 @@ HISTOGRAM_BINS = 15
 PRINT_RESULT_FIELDS_FILTER = (
     TRAINING_ITERATION,
     TIME_TOTAL_S,
-    NUM_ENV_STEPS_SAMPLED_LIFETIME,
-    NUM_EPISODES_LIFETIME,
+    "/".join((ENV_RUNNER_RESULTS, NUM_ENV_STEPS_SAMPLED_LIFETIME)),
+    "/".join((ENV_RUNNER_RESULTS, NUM_EPISODES_LIFETIME)),
     "/".join((ENV_RUNNER_RESULTS, EPISODE_RETURN_MAX)),
     "/".join((ENV_RUNNER_RESULTS, EPISODE_RETURN_MEAN)),
     "/".join((ENV_RUNNER_RESULTS, EPISODE_LEN_MEAN)),
@@ -823,7 +823,9 @@ def train(algo_config: AlgorithmConfig,
                 result_flat = flatten_dict(result, delimiter="/")
                 for field in PRINT_RESULT_FIELDS_FILTER:
                     if field in result_flat.keys():
-                        msg_data.append(f"{field}: {result_flat[field]:.5g}")
+                        msg_data.append(
+                            f"{field.split("/")[-1]}: "
+                            f"{result_flat[field]:.5g}")
                 print(" - ".join(msg_data))
 
             # Backup the policy
@@ -1131,7 +1133,7 @@ def _pretty_print_statistics(data: Sequence[Tuple[str, np.ndarray]]) -> None:
                 f"(min = {np.min(values):.2f}, max = {np.max(values):.2f})")
 
 
-def _pretty_print_episode_metrics(all_episodes: List[EpisodeType],
+def _pretty_print_episode_metrics(all_episodes: Sequence[EpisodeType],
                                   step_dt: Optional[float]) -> None:
     """Render ASCII histograms horizontally side-by-side of high-level
     performance metrics about the batch of episodes.
@@ -1292,7 +1294,7 @@ def evaluate_from_algo(algo: Algorithm,
 
     # Centralized all metrics in algorithm logger
     algo.metrics.merge_and_log_n_dicts(
-        all_metrics, key=(EVALUATION_RESULTS, ENV_RUNNER_RESULTS))
+        list(all_metrics), key=(EVALUATION_RESULTS, ENV_RUNNER_RESULTS))
 
     # Early return if computing reduced metrics is not requested.
     # Note that it expects a non-empty `ResultDict` as first output, even

--- a/python/gym_jiminy/rllib/setup.py
+++ b/python/gym_jiminy/rllib/setup.py
@@ -31,7 +31,8 @@ setup(
     install_requires=[
         f"gym-jiminy~={gym_jiminy_version}",
         # Highly efficient distributed computation library used for RL
-        "ray[rllib]>=2.38,<=2.39",
+        # - bound version for resilience to recurrent API breakage
+        "ray[rllib]>=2.38,<=2.40",
         # Used for monitoring (logging and publishing) learning progress
         "tensorboardX",
         # Plot data directly in terminal to monitor stats w/o display server

--- a/python/gym_jiminy/unit_py/data/anymal_pipeline.toml
+++ b/python/gym_jiminy/unit_py/data/anymal_pipeline.toml
@@ -18,7 +18,7 @@ cls = "gym_jiminy.common.compositions.BaseRollPitchTermination"
 low = [-0.2, -0.05]
 high = [-0.05, 0.3]
 grace_period = 0.1
-is_training_only = false
+training_only = false
 
 # ========================== Ad-hoc reward components =========================
 

--- a/python/gym_jiminy/unit_py/test_pipeline_control.py
+++ b/python/gym_jiminy/unit_py/test_pipeline_control.py
@@ -351,6 +351,6 @@ class PipelineControl(unittest.TestCase):
             if isinstance(value, dict):
                 obs_nodes += value.values()
             else:
-                all_values_flat.append(value.flatten())
+                all_values_flat.append(value.ravel(order='F'))
         obs_flat = np.concatenate(all_values_flat[::-1])
         np.testing.assert_allclose(env_flat.observation, obs_flat)

--- a/python/gym_jiminy/unit_py/test_terminations.py
+++ b/python/gym_jiminy/unit_py/test_terminations.py
@@ -99,7 +99,7 @@ class TerminationConditions(unittest.TestCase):
                     grace_period=0.2,
                     op=op,
                     is_truncation=is_truncation,
-                    is_training_only=is_training_only
+                    training_only=is_training_only
                 ) for name, (quantity_cls, quantity_kwargs), low, high, op in (
                     termination_pos_config, termination_rot_config))
 
@@ -130,7 +130,7 @@ class TerminationConditions(unittest.TestCase):
                     time = self.env.stepper_state.t
                     is_active = (
                         time >= termination.grace_period and
-                        not termination.is_training_only)
+                        not termination.training_only)
                     assert info == {
                         termination.name: EpisodeState.TERMINATED
                         if terminated else EpisodeState.TRUNCATED
@@ -156,7 +156,7 @@ class TerminationConditions(unittest.TestCase):
             0.3,
             quat_difference)
 
-        for i, (is_truncation, is_training_only) in enumerate((
+        for i, (is_truncation, training_only) in enumerate((
             (False, False), (True, False), (False, True))):
             termination_pos, termination_rot = (
                 ShiftTrackingQuantityTermination(
@@ -171,7 +171,7 @@ class TerminationConditions(unittest.TestCase):
                     grace_period=0.2,
                     op=op,
                     is_truncation=is_truncation,
-                    is_training_only=is_training_only
+                    training_only=training_only
                 ) for name, (quantity_cls, quantity_kwargs), thr, op in (
                     termination_pos_config, termination_rot_config))
 
@@ -213,7 +213,7 @@ class TerminationConditions(unittest.TestCase):
                     time = self.env.stepper_state.t
                     is_active = (
                         time >= termination.grace_period and
-                        not termination.is_training_only)
+                        not termination.training_only)
                     assert info == {
                         termination.name: EpisodeState.TERMINATED
                         if terminated else EpisodeState.TRUNCATED


### PR DESCRIPTION
* [core] Improve error handling in 'Engine.read_log'.
* [gym_jiminy/common] Add 'order' input argument to 'build_flatten'. Speed up 1D special case.
* [gym_jiminy/common] Use fortran order for flattening wrappers 'Flatten(Observation|Action)'.
* [gym_jiminy/common] Train/eval mode API of InterfaceJiminyEnv is now consistent with PyTorch.
* [gym_jiminy/common] Refactor evaluation log file logics to allow for parallel evaluation.
* [gym_jiminy/rllib] Specify infer obs/act mirroring spec in args w/o relying on space. Only support vector obs/act.
* [gym_jiminy/rllib] Fix extremely slow shallow batch copy.
* [gym_jiminy/rllib] Fix broken 'MeanStdFilter' for 'ray<=2.40'.
* [misc] Add support of 'gymnasium==1.0'.
* [misc] Add support of 'ray[rllib]==2.40'.