### PR TITLE
Various minor bug fixes and improvements.

### DIFF
--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -25,9 +25,14 @@
 #include "H5Cpp.h"
 #include "json/json.h"
 
+#define HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+#include "hpp/fcl/serialization/collision_object.h"  // `serialize<hpp::fcl::CollisionGeometry>`
+#undef HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+
 #include "jiminy/core/telemetry/fwd.h"
 #include "jiminy/core/hardware/fwd.h"
 #include "jiminy/core/utilities/helpers.h"
+#include "jiminy/core/utilities/geometry.h"
 #include "jiminy/core/utilities/pinocchio.h"
 #include "jiminy/core/utilities/json.h"
 #include "jiminy/core/io/file_device.h"
@@ -1498,6 +1503,14 @@ namespace jiminy
             const std::string key =
                 addCircumfix("robot", robot->getName(), {}, TELEMETRY_FIELDNAME_DELIMITER);
             telemetrySender_->registerConstant(key, saveToBinary(robot, isPersistent));
+        }
+
+        // Log the ground profile if requested
+        if (engineOptions_->telemetry.isPersistent)
+        {
+            hpp::fcl::CollisionGeometryPtr_t heightmap = discretizeHeightmap(
+                engineOptions_->world.groundProfile, -10.0, 10.0, 0.04, -10.0, 10.0, 0.04);
+            telemetrySender_->registerConstant("groundProfile", saveToBinary(heightmap));
         }
 
         // Log all options

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
@@ -227,7 +227,7 @@ class InterfaceJiminyEnv(
         # with the updated state of the agent.
         self.__is_observation_refreshed = True
 
-        # Store latest engine measurement for efficiency
+        # Store latest engine measurement
         self.measurement = EngineObsType(
             t=np.array(0.0),
             states=OrderedDict(
@@ -237,7 +237,6 @@ class InterfaceJiminyEnv(
             measurements=OrderedDict(zip(
                 self.robot.sensor_measurements.keys(),
                 map(np.copy, self.robot.sensor_measurements.values()))))
-        self._sensors_types = tuple(self.robot.sensor_measurements.keys())
 
         # Define flattened engine measurement for efficiency
         agent_state = self.measurement['states']['agent']

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -1064,9 +1064,11 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 obs, reward, terminated, truncated, info = env.step(action)
                 info_episode.append(info)
                 reward_episode.append(float(reward))
-            env.stop()
         except KeyboardInterrupt:
             pass
+
+        # Stop the simulation
+        env.stop()
 
         # Restore training mode if it was enabled
         if is_training:

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
@@ -668,7 +668,7 @@ def save_trajectory_to_hdf5(trajectory: Trajectory,
             hdf_obj.create_dataset(name=f"states/{key}", data=data)
 
     # Dump serialized robot
-    robot_data = jiminy.save_to_binary(trajectory.robot)
+    robot_data = jiminy.save_robot_to_binary(trajectory.robot)
     dataset = hdf_obj.create_dataset(name="robot", data=np.array(robot_data))
 
     # Dump whether to use the theoretical model of the robot
@@ -710,7 +710,7 @@ def load_trajectory_from_hdf5(
     robot_data += b'\0' * (
         dataset.nbytes - len(robot_data))  # pylint: disable=no-member
     try:
-        robot = jiminy.load_from_binary(robot_data)
+        robot = jiminy.load_robot_from_binary(robot_data)
     except MemoryError as e:
         raise MemoryError(
             "Impossible to build robot from serialized binary data. Make sure "

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
@@ -476,7 +476,7 @@ def build_pipeline(
 
         # Instantiate the block associated with the wrapper if any
         if block_cls is not None:
-            block_name = block_kwargs.pop("name", None)
+            block_name = block_kwargs.get("name", None)
             if block_name is None:
                 block_index = 0
                 env_wrapper: gym.Env = env
@@ -494,8 +494,9 @@ def build_pipeline(
                     ).lower()
                 if block_index:
                     block_name += f"_{block_index}"
+                block_kwargs["name"] = block_name
 
-            block = block_cls(block_name, env, **block_kwargs)
+            block = block_cls(env=env, **block_kwargs)
             args.append(block)
 
         # Instantiate the wrapper

--- a/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
+++ b/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
@@ -273,8 +273,8 @@ def compute_distance_convex_to_ray(
             collision = ratio * vectors[j] + vertices[j]
             oriented_ray = collision - query_origin
             if oriented_ray.dot(query_dir) > 0.0:
-                casting_dist = min(  # type: ignore[assignment]
-                    np.linalg.norm(oriented_ray), casting_dist)
+                casting_dist = min(
+                    float(np.linalg.norm(oriented_ray)), casting_dist)
                 collide_num += 1
 
     # If the ray is intersecting with two edges and the sign of the oriented

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -143,7 +143,7 @@ def build_robot_from_log(
     robot_data = log_constants[".".join(filter(None, (robot_name, "robot")))]
 
     # Load robot from binary data
-    return jiminy.load_from_binary(
+    return jiminy.load_robot_from_binary(
         robot_data, mesh_dir_path, mesh_package_dirs)
 
 

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -824,10 +824,14 @@ class Simulator:
         # Enable the ground profile is requested and available
         assert self.viewer is not None and self.viewer.backend is not None
         if update_ground_profile:
+            # Discretize ground profile
             engine_options = self.engine.get_options()
             ground_profile = engine_options["world"]["groundProfile"]
-            Viewer.update_floor(
-                ground_profile, simplify_mesh=True, show_vertices=False)
+            geom = jiminy.discretize_heightmap(
+                ground_profile, *((-10.0, 10.0, 0.04) * 2), must_simplify=True)
+
+            # Update viewer
+            Viewer.update_floor(geom, show_vertices=False)
 
         # Set the camera pose if requested
         if camera_pose is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -45,9 +45,7 @@ from pinocchio.rpy import (  # pylint: disable=import-error
     rpyToMatrix, matrixToRpy)
 
 from .. import core as jiminy
-from ..core import (  # pylint: disable=no-name-in-module
-    ContactSensor,
-    discretize_heightmap)
+from ..core import ContactSensor  # pylint: disable=no-name-in-module
 from ..robot import _DuplicateFilter
 from ..dynamics import Trajectory
 from ..log import UpdateHook
@@ -832,7 +830,7 @@ class Viewer:
                                 pose=[frame_pose.translation, None],
                                 remove_if_exists=True,
                                 auto_refresh=False,
-                                radius=0.01)
+                                radius=0.006)
 
             self.display_contact_frames(self._display_contact_frames)
 
@@ -1840,34 +1838,17 @@ class Viewer:
     @staticmethod
     @_with_lock
     @_must_be_open
-    def update_floor(ground_profile: Optional[jiminy.HeightmapFunction] = None,
-                     x_range: Tuple[float, float] = (-10.0, 10.0),
-                     y_range: Tuple[float, float] = (-10.0, 10.0),
-                     grid_unit:  Tuple[float, float] = (0.04, 0.04),
-                     simplify_mesh: bool = False,
+    def update_floor(geom: Optional[hppfcl.CollisionGeometry] = None,
                      show_vertices: bool = False) -> None:
         """Display a custom ground profile as a height map or the original tile
         ground floor.
 
-        :param ground_profile: `jiminy_py.core.HeightmapFunction` associated
-                               with the ground profile. It renders a flat tile
-                               ground if not specified.
-                               Optional: None by default.
-        :param x_range: Tuple gathering min and max limits along x-axis for
-                        which the heightmap mesh associated with the ground
-                        profile will be procedurally generated.
-                        Optional: (-10.0, 10.0) by default.
-        :param y_range: Tuple gathering min and max limits along y-axis.
-                        Optional: (-10.0, 10.0) by default.
-        :param grid_unit: Tuple gathering X and Y discretization steps for the
-                          generation of the heightmap mesh.
-                          Optional: 4cm by default.
-        :param simplify_mesh: Whether the generated heightmap mesh should be
-                              decimated before final rendering. This option
-                              must be enabled for the ratio between grid size
-                              and unit is very large to avoid a prohibitive
-                              slowdown of the viewer.
-                              Optional: False by default
+        :param geom: Collision geometry associated with the ground profile. A
+                     flat tile ground will be rendered if not specified. Note
+                     that symbolic function `jiminy_py.core.HeightmapFunction`
+                     can be converted in collision geometry by calling
+                     `jiminy_py.core.discretize_heightmap`.
+                     Optional: None by default.
         :param show_vertices: Whether to highlight the mesh vertices.
                               Optional: disabled by default.
         """
@@ -1876,13 +1857,6 @@ class Viewer:
         # Assert(s) for type checker
         assert Viewer.backend is not None
         assert Viewer._backend_obj is not None
-
-        # Discretize ground profile if provided
-        geom = None
-        if ground_profile is not None:
-            geom = discretize_heightmap(
-                ground_profile, *x_range, grid_unit[0], *y_range, grid_unit[1],
-                must_simplify=simplify_mesh)
 
         # Render original flat tile ground if possible.
         # TODO: Improve this check using LocalAABB box geometry instead.

--- a/python/jiminy_pywrap/src/helpers.cc
+++ b/python/jiminy_pywrap/src/helpers.cc
@@ -8,6 +8,10 @@
 #include "jiminy/core/utilities/pinocchio.h"
 #include "jiminy/core/utilities/random.h"
 
+#define HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+#include "hpp/fcl/serialization/collision_object.h"  // `serialize<hpp::fcl::CollisionGeometry>`
+#undef HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+
 #define NO_IMPORT_ARRAY
 #include "jiminy/python/fwd.h"
 #include "jiminy/python/utilities.h"
@@ -88,6 +92,13 @@ namespace jiminy::python
         std::shared_ptr<jiminy::Robot> robot;
         loadFromBinary(robot, data, meshPathDir, meshPackageDirs);
         return robot;
+    }
+
+    hpp::fcl::CollisionGeometryPtr_t buildHeightmapFromBinary(const std::string & data)
+    {
+        hpp::fcl::CollisionGeometryPtr_t heightmap;
+        loadFromBinary(heightmap, data);
+        return heightmap;
     }
 
     np::ndarray solveJMinvJtv(
@@ -366,13 +377,15 @@ namespace jiminy::python
                  bp::arg("build_visual_model") = false,
                  bp::arg("load_visual_meshes") = false));
 
-        bp::def("save_to_binary", &saveRobotToBinary, (bp::arg("robot")));
+        bp::def("save_robot_to_binary", &saveRobotToBinary, (bp::arg("robot")));
 
-        bp::def("load_from_binary",
+        bp::def("load_robot_from_binary",
                 &buildRobotFromBinary,
                 (bp::arg("data"),
                  bp::arg("mesh_dir_path") = bp::object(),
                  bp::arg("mesh_package_dirs") = bp::list()));
+
+        bp::def("load_heightmap_from_binary", &buildHeightmapFromBinary, bp::arg("data"));
 
         bp::def("get_joint_type", &getJointType, bp::arg("joint_model"));
         bp::def(


### PR DESCRIPTION
* [core/python] Fix 'SensorMeasurementTree' not supporting instantiation from 'OrderedDict'.
* [core|python] Ground profile now included in persistent log files and automatically loaded for replay.
* [gym_jiminy/common] Move initial state sampling after reset all of the layers of the pipeline.
* [gym_jiminy/common] Fix 'env.stop' not being called at the end of evaluation if keyboard-interrupted.
* [gym_jiminy/common] Fix loaded pipeline config file cannot be instantiated more than once.