### PR TITLE
Jiminy release 1.8.11 (follow-up)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        PYTHON_VERSION: ['3.10', '3.11', '3.12']
+        PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
         BUILD_TYPE: ['Release']
         include:
           - PYTHON_VERSION: '3.12'
@@ -69,10 +69,9 @@ jobs:
 
         git config --global advice.detachedHead false
     - name: Install pre-compiled binaries for additional gym-jiminy dependencies
-      if: matrix.PYTHON_VERSION != '3.13'
       run: |
-        "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
+        "${PYTHON_EXECUTABLE}" -m pip install torch -f https://download.pytorch.org/whl/torch
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.1" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         "${PYTHON_EXECUTABLE}" -m pip install --upgrade "numpy>=1.24" numba torch
@@ -95,7 +94,6 @@ jobs:
               -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE -DBoost_USE_STATIC_LIBS=ON \
               -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
-              -DINSTALL_GYM_JIMINY=${{ (matrix.PYTHON_VERSION == '3.13' && 'OFF') || 'ON' }} \
               -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_BUILD_TYPE="${{ matrix.BUILD_TYPE }}"
         make install -j4
 
@@ -133,7 +131,7 @@ jobs:
         "${PYTHON_EXECUTABLE}" -m unittest discover -s "${RootDir}/python/gym_jiminy/unit_py" -v
 
     - name: Run examples for gym jiminy add-on modules
-      if: matrix.BUILD_TYPE != 'Debug'
+      if: matrix.BUILD_TYPE != 'Debug' && matrix.PYTHON_VERSION != '3.13'
       run: |
         cd "${RootDir}/python/gym_jiminy/examples/rllib"
         "${PYTHON_EXECUTABLE}" acrobot_ppo.py

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         OS: ['macos-15']  # 'macos-13': Intel (x86), 'macos-14+': Apple Silicon (arm64)
-        PYTHON_VERSION: ['3.10', '3.11', '3.12']  # `setup-python` does not support Python<3.10 on Apple Silicon
+        PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']  # `setup-python` does not support Python<3.10 on Apple Silicon
         BUILD_TYPE: ['Release']
         include:
           - OS: 'macos-13'
@@ -72,10 +72,14 @@ jobs:
         "${PYTHON_EXECUTABLE}" -m pip install setuptools wheel "pip>=20.3"
         "${PYTHON_EXECUTABLE}" -m pip install delocate twine
     - name: Install pre-compiled binaries for additional gym-jiminy dependencies
-      if: matrix.PYTHON_VERSION != '3.13'
       run: |
-        "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
+        # FIXME: Pre-release 2.6 is needed to install torch for Python 3.13 on MacOS
+        if [[ "${{ matrix.OS }}" != 'macos-13' ]] ; then
+          "${PYTHON_EXECUTABLE}" -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        else
+          "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
+        fi
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.1" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         if [[ "${{ matrix.BUILD_TYPE }}" != 'Debug' && "${{ matrix.OS }}" != 'macos-13' ]] ; then
@@ -114,7 +118,6 @@ jobs:
               -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \
               -DBoost_USE_STATIC_LIBS=ON -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
-              -DINSTALL_GYM_JIMINY=${{ (matrix.PYTHON_VERSION == '3.13' && 'OFF') || 'ON' }} \
               -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_BUILD_TYPE="${{ matrix.BUILD_TYPE }}"
         make -j4
 
@@ -214,7 +217,7 @@ jobs:
         "${PYTHON_EXECUTABLE}" -m unittest discover -s "${RootDir}/python/gym_jiminy/unit_py" -v
 
     - name: Run examples for gym jiminy add-on modules
-      if: matrix.BUILD_TYPE != 'Debug'
+      if: matrix.BUILD_TYPE != 'Debug' && matrix.PYTHON_VERSION != '3.13'
       run: |
         export LD_LIBRARY_PATH="${InstallDir}/lib/:/usr/local/lib"
 

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        PYTHON_VERSION: ['cp310', 'cp311', 'cp312']
+        PYTHON_VERSION: ['cp310', 'cp311', 'cp312', 'cp313']
         OS: [ubuntu-24.04]
         include:
           - OS: ubuntu-24.04
@@ -48,7 +48,8 @@ jobs:
     - name: Setup minimal build environment
       run: |
         pythonLocation=$(find /opt/python -maxdepth 1 -name \
-          "$(echo "${{ matrix.PYTHON_VERSION }}*" | sed -e 's/\.//g')" -print -quit)
+          "$(echo "${{ matrix.PYTHON_VERSION }}*" | sed -e 's/\.//g')" -print \
+          | LC_COLLATE=C sort | head -n 1)
 
         echo "export PATH=\"${pythonLocation}/bin:\$PATH\"" >> $HOME/.bashrc
         source $HOME/.bashrc
@@ -87,7 +88,6 @@ jobs:
               -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE \
               -DBoost_USE_STATIC_LIBS=ON -DPYTHON_EXECUTABLE="${PYTHON_EXECUTABLE}" \
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON \
-              -DINSTALL_GYM_JIMINY=${{ (matrix.PYTHON_VERSION == 'cp313' && 'OFF') || 'ON' }} \
               -DCMAKE_CXX_FLAGS="${CXX_FLAGS}" -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
         make -j4
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -75,8 +75,8 @@ jobs:
         if [[ "${{ matrix.GENERATOR }}" == 'Ninja' ]] ; then
           sudo apt install ninja-build
         fi
-        "${PYTHON_EXECUTABLE}" -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
+        "${PYTHON_EXECUTABLE}" -m pip install torch -f https://download.pytorch.org/whl/torch
+        "${PYTHON_EXECUTABLE}" -m pip install "gymnasium>=0.28,<1.1" "stable_baselines3>=2.0,<2.5"
 
     #####################################################################################
 

--- a/.github/workflows/win.yml
+++ b/.github/workflows/win.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        PYTHON_VERSION: ['3.10', '3.11', '3.12']
+        PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
         BUILD_TYPE: ['Release']
         include:
           - PYTHON_VERSION: '3.12'
@@ -58,10 +58,10 @@ jobs:
         python -m pip install setuptools wheel "pip>=20.3"
         python -m pip install pefile machomachomangler
     - name: Install pre-compiled binaries for additional gym-jiminy dependencies
-      if: matrix.PYTHON_VERSION != '3.13'
       run: |
-        python -m pip install "torch" -f https://download.pytorch.org/whl/torch
-        python -m pip install "gymnasium>=0.28,<=1.0" "stable_baselines3>=2.0,<2.5"
+        # FIXME: Pre-release 2.6 is needed to install torch for Python 3.13 on Windows
+        python -m pip install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
+        python -m pip install "gymnasium>=0.28,<1.1" "stable_baselines3>=2.0,<2.5"
     - name: Install latest numpy version at build-time for run-time binary compatibility
       run: |
         python -m pip install --upgrade "numpy>=1.24" numba torch
@@ -100,7 +100,6 @@ jobs:
               -DBoost_NO_SYSTEM_PATHS=TRUE -DBoost_NO_BOOST_CMAKE=TRUE `
               -DBoost_USE_STATIC_LIBS=ON -DPYTHON_REQUIRED_VERSION="${{ matrix.PYTHON_VERSION }}" `
               -DBUILD_TESTING=ON -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_INTERFACE=ON `
-              -DINSTALL_GYM_JIMINY=${{ ((matrix.PYTHON_VERSION == '3.13') && 'OFF') || 'ON' }} `
               -DCMAKE_CXX_FLAGS="${env:CXX_FLAGS} $(
               ) -DBOOST_ALL_NO_LIB -DBOOST_LIB_DIAGNOSTIC -DBOOST_CORE_USE_GENERIC_CMATH $(
               ) -DEIGENPY_STATIC -DURDFDOM_STATIC -DHPP_FCL_STATIC -DPINOCCHIO_STATIC"
@@ -124,15 +123,17 @@ jobs:
         ${env:Path} += ";$InstallDir/lib"
 
         # Generate stubs
-        # FIXME: stubgen does not work with Numpy 2.X
-        # (see https://github.com/python/mypy/issues/17396)
-        python -m pip install "numpy<2.0"
-        stubgen -p jiminy_py -o $RootDir/build/pypi/jiminy_py/src
-        python "$RootDir/build_tools/stubgen.py" `
-          -o $RootDir/build/stubs --ignore-invalid=all jiminy_py
-        Copy-Item -Force -Path "$RootDir/build/stubs/jiminy_py-stubs/core/__init__.pyi" `
-                  -Destination "$RootDir/build/pypi/jiminy_py/src/jiminy_py/core/core.pyi"
-        python -m pip install --upgrade "numpy>=1.24" numba torch
+        if ("${{ matrix.PYTHON_VERSION }}" -ne "3.13") {
+          # FIXME: stubgen does not work with Numpy 2.X
+          # (see https://github.com/python/mypy/issues/17396)
+          python -m pip install "numpy<2.0"
+          stubgen -p jiminy_py -o $RootDir/build/pypi/jiminy_py/src
+          python "$RootDir/build_tools/stubgen.py" `
+            -o $RootDir/build/stubs --ignore-invalid=all jiminy_py
+          Copy-Item -Force -Path "$RootDir/build/stubs/jiminy_py-stubs/core/__init__.pyi" `
+                    -Destination "$RootDir/build/pypi/jiminy_py/src/jiminy_py/core/core.pyi"
+          python -m pip install --upgrade "numpy>=1.24" numba torch
+        }
 
         # Generate wheels
         Set-Location -Path "$RootDir/build"
@@ -202,7 +203,7 @@ jobs:
         python -m unittest discover -s "$RootDir/python/gym_jiminy/unit_py" -v
 
     - name: Run examples for gym jiminy add-on modules
-      if: matrix.BUILD_TYPE != 'Debug'
+      if: matrix.BUILD_TYPE != 'Debug' && matrix.PYTHON_VERSION != '3.13'
       run: |
         $RootDir = "${env:GITHUB_WORKSPACE}/workspace" -replace '\\', '/'
 

--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -25,9 +25,14 @@
 #include "H5Cpp.h"
 #include "json/json.h"
 
+#define HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+#include "hpp/fcl/serialization/collision_object.h"  // `serialize<hpp::fcl::CollisionGeometry>`
+#undef HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+
 #include "jiminy/core/telemetry/fwd.h"
 #include "jiminy/core/hardware/fwd.h"
 #include "jiminy/core/utilities/helpers.h"
+#include "jiminy/core/utilities/geometry.h"
 #include "jiminy/core/utilities/pinocchio.h"
 #include "jiminy/core/utilities/json.h"
 #include "jiminy/core/io/file_device.h"
@@ -1498,6 +1503,14 @@ namespace jiminy
             const std::string key =
                 addCircumfix("robot", robot->getName(), {}, TELEMETRY_FIELDNAME_DELIMITER);
             telemetrySender_->registerConstant(key, saveToBinary(robot, isPersistent));
+        }
+
+        // Log the ground profile if requested
+        if (engineOptions_->telemetry.isPersistent)
+        {
+            hpp::fcl::CollisionGeometryPtr_t heightmap = discretizeHeightmap(
+                engineOptions_->world.groundProfile, -10.0, 10.0, 0.04, -10.0, 10.0, 0.04);
+            telemetrySender_->registerConstant("groundProfile", saveToBinary(heightmap));
         }
 
         // Log all options

--- a/core/src/engine/engine.cc
+++ b/core/src/engine/engine.cc
@@ -1505,11 +1505,12 @@ namespace jiminy
             telemetrySender_->registerConstant(key, saveToBinary(robot, isPersistent));
         }
 
-        // Log the ground profile if requested
+        // Log the (simplified) ground profile if requested
         if (engineOptions_->telemetry.isPersistent)
         {
-            hpp::fcl::CollisionGeometryPtr_t heightmap = discretizeHeightmap(
-                engineOptions_->world.groundProfile, -10.0, 10.0, 0.04, -10.0, 10.0, 0.04);
+            const HeightmapFunction & groundProfile = engineOptions_->world.groundProfile;
+            hpp::fcl::CollisionGeometryPtr_t heightmap =
+                discretizeHeightmap(groundProfile, -10.0, 10.0, 0.04, -10.0, 10.0, 0.04, true);
             telemetrySender_->registerConstant("groundProfile", saveToBinary(heightmap));
         }
 

--- a/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/bases/interfaces.py
@@ -227,7 +227,7 @@ class InterfaceJiminyEnv(
         # with the updated state of the agent.
         self.__is_observation_refreshed = True
 
-        # Store latest engine measurement for efficiency
+        # Store latest engine measurement
         self.measurement = EngineObsType(
             t=np.array(0.0),
             states=OrderedDict(
@@ -237,7 +237,6 @@ class InterfaceJiminyEnv(
             measurements=OrderedDict(zip(
                 self.robot.sensor_measurements.keys(),
                 map(np.copy, self.robot.sensor_measurements.values()))))
-        self._sensors_types = tuple(self.robot.sensor_measurements.keys())
 
         # Define flattened engine measurement for efficiency
         agent_state = self.measurement['states']['agent']

--- a/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/envs/generic.py
@@ -620,25 +620,16 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 "Controller update period must be a divisor of environment "
                 "simulation timestep")
 
-        # Sample the initial state and reset the low-level engine
-        q_init, v_init = self._sample_state()
-        if not jiminy.is_position_valid(self.robot.pinocchio_model, q_init):
-            raise RuntimeError(
-                "The initial state provided by `_sample_state` is "
-                "inconsistent with the dimension or types of joints of the "
-                "model.")
-
-        # Set robot in initial configuration
-        pin.framesForwardKinematics(
-            self.robot.pinocchio_model, self.robot.pinocchio_data, q_init)
-
         # Initialize sensor measurements that are zero-ed at this point. This
         # may be necessary for pre-compiling blocks before actually starting
         # the simulation to avoid triggering timeout error. Indeed, some
         # computations may require valid sensor data, such as normalized
         # quaternion or non-zero linear acceleration.
-        a_init, u_motor = (np.zeros(self.robot.nv),) * 2
+        q_init = self._neutral()
+        v_init, a_init, u_motor = (np.zeros(self.robot.nv),) * 3
         f_external = [pin.Force.Zero(),] * self.robot.pinocchio_model.njoints
+        pin.framesForwardKinematics(
+            self.robot.pinocchio_model, self.robot.pinocchio_data, q_init)
         self.robot.compute_sensor_measurements(
             0.0, q_init, v_init, a_init, u_motor, f_external)
 
@@ -658,6 +649,18 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
         # Update the environment pipeline if necessary
         if env is not self.derived:
             env._update_pipeline(env)
+
+        # Sample the initial state
+        # Note that it is important to postpone initial state sampling to after
+        # calling `reset` for all the layers of the pipeline, as some of them
+        # may affect the base environment. Notably, by selecting the reference
+        # trajectory, which in turns, may be involve in the initial condition.
+        q_init, v_init = self._sample_state()
+        if not jiminy.is_position_valid(self.robot.pinocchio_model, q_init):
+            raise RuntimeError(
+                "The initial state provided by `_sample_state` is "
+                "inconsistent with the dimension or types of joints of the "
+                "model.")
 
         # Re-initialize the quantity manager.
         # Note that computation graph tracking is never reset automatically.
@@ -1061,9 +1064,11 @@ class BaseJiminyEnv(InterfaceJiminyEnv[Obs, Act],
                 obs, reward, terminated, truncated, info = env.step(action)
                 info_episode.append(info)
                 reward_episode.append(float(reward))
-            env.stop()
         except KeyboardInterrupt:
             pass
+
+        # Stop the simulation
+        env.stop()
 
         # Restore training mode if it was enabled
         if is_training:

--- a/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/quantities/generic.py
@@ -1633,7 +1633,10 @@ class MultiActuatedJointKinematic(AbstractQuantity[np.ndarray]):
         joint_to_motor_ratios = []
         self.kinematic_indices.clear()
         for motor in self.robot.motors:
-            joint = self.pinocchio_model.joints[motor.joint_index]
+            # Note that pinocchio model may be theoretical or extended, which
+            # means that `motor.joint_index` cannot be used reliably.
+            joint_index = self.pinocchio_model.getJointId(motor.joint_name)
+            joint = self.pinocchio_model.joints[joint_index]
             joint_type = jiminy.get_joint_type(joint)
             if joint_type == jiminy.JointModelType.ROTARY_UNBOUNDED:
                 raise ValueError(

--- a/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/utils/pipeline.py
@@ -476,7 +476,7 @@ def build_pipeline(
 
         # Instantiate the block associated with the wrapper if any
         if block_cls is not None:
-            block_name = block_kwargs.pop("name", None)
+            block_name = block_kwargs.get("name", None)
             if block_name is None:
                 block_index = 0
                 env_wrapper: gym.Env = env
@@ -494,8 +494,9 @@ def build_pipeline(
                     ).lower()
                 if block_index:
                     block_name += f"_{block_index}"
+                block_kwargs["name"] = block_name
 
-            block = block_cls(block_name, env, **block_kwargs)
+            block = block_cls(env=env, **block_kwargs)
             args.append(block)
 
         # Instantiate the wrapper
@@ -667,7 +668,7 @@ def save_trajectory_to_hdf5(trajectory: Trajectory,
             hdf_obj.create_dataset(name=f"states/{key}", data=data)
 
     # Dump serialized robot
-    robot_data = jiminy.save_to_binary(trajectory.robot)
+    robot_data = jiminy.save_robot_to_binary(trajectory.robot)
     dataset = hdf_obj.create_dataset(name="robot", data=np.array(robot_data))
 
     # Dump whether to use the theoretical model of the robot
@@ -709,7 +710,7 @@ def load_trajectory_from_hdf5(
     robot_data += b'\0' * (
         dataset.nbytes - len(robot_data))  # pylint: disable=no-member
     try:
-        robot = jiminy.load_from_binary(robot_data)
+        robot = jiminy.load_robot_from_binary(robot_data)
     except MemoryError as e:
         raise MemoryError(
             "Impossible to build robot from serialized binary data. Make sure "

--- a/python/gym_jiminy/common/gym_jiminy/common/wrappers/scale.py
+++ b/python/gym_jiminy/common/gym_jiminy/common/wrappers/scale.py
@@ -217,6 +217,8 @@ class ScaleObservation(BaseTransformObservation[ScaledObs, Obs, Act],
                 copy_ops.append((dst, src))
             observation_flat.append(dst)
         if copy_ops:
+            # FIXME: Could be optimized by avoiding copying fields for which
+            # the union of extracted slices is covering the whole subspace.
             self._copyto_dst, self._copyto_src = map(tuple, zip(*copy_ops))
         else:
             self._copyto_dst, self._copyto_src = (), ()
@@ -234,7 +236,7 @@ class ScaleObservation(BaseTransformObservation[ScaledObs, Obs, Act],
     def transform_observation(self) -> None:
         # First, copy the value of some leaves.
         # Guarding function call is faster than calling no-op python bindings.
-        if not self._copyto_dst:
+        if self._copyto_dst:
             multi_array_copyto(self._copyto_dst, self._copyto_src)
 
         # Apply scaling factor sequentially on some chunks

--- a/python/gym_jiminy/common/setup.py
+++ b/python/gym_jiminy/common/setup.py
@@ -31,7 +31,7 @@ setup(
                   "@PROJECT_VERSION@.tar.gz"),
     maintainer="Alexis Duburcq",
     license="MIT",
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
@@ -40,7 +40,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),

--- a/python/gym_jiminy/envs/setup.py
+++ b/python/gym_jiminy/envs/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",
     license="MIT",
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
@@ -22,7 +22,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),

--- a/python/gym_jiminy/rllib/setup.py
+++ b/python/gym_jiminy/rllib/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",
     license="MIT",
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: Science/Research",
@@ -23,7 +23,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),

--- a/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
+++ b/python/gym_jiminy/toolbox/gym_jiminy/toolbox/math/qhull.py
@@ -273,8 +273,8 @@ def compute_distance_convex_to_ray(
             collision = ratio * vectors[j] + vertices[j]
             oriented_ray = collision - query_origin
             if oriented_ray.dot(query_dir) > 0.0:
-                casting_dist = min(  # type: ignore[assignment]
-                    np.linalg.norm(oriented_ray), casting_dist)
+                casting_dist = min(
+                    float(np.linalg.norm(oriented_ray)), casting_dist)
                 collide_num += 1
 
     # If the ray is intersecting with two edges and the sign of the oriented

--- a/python/gym_jiminy/toolbox/setup.py
+++ b/python/gym_jiminy/toolbox/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",
     license="MIT",
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",
@@ -23,7 +23,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     keywords="reinforcement-learning robotics gym jiminy",
     packages=find_namespace_packages(),

--- a/python/gym_jiminy/unit_py/test_task_curriculum.py
+++ b/python/gym_jiminy/unit_py/test_task_curriculum.py
@@ -11,16 +11,21 @@ from typing import Any, Callable, Dict
 import numpy as np
 import gymnasium as gym
 
-import ray
-from ray.tune.registry import register_env
-from ray.rllib.algorithms import PPOConfig
-from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
+try:
+    import ray
+    from ray.tune.registry import register_env
+    from ray.rllib.algorithms import PPOConfig
+    from ray.rllib.core.rl_module.default_model_config import DefaultModelConfig
+    IS_RAY_AVAILABLE = True
+except ImportError:
+    IS_RAY_AVAILABLE = False
 
 from gym_jiminy.common.wrappers import FlattenObservation
 from gym_jiminy.envs import AcrobotJiminyEnv
 from gym_jiminy.toolbox.wrappers.meta_envs import BaseTaskSettableWrapper
-from gym_jiminy.rllib.utilities import initialize, train
-from gym_jiminy.rllib.curriculum import build_task_scheduling_callback
+if IS_RAY_AVAILABLE:
+    from gym_jiminy.rllib.utilities import initialize, train
+    from gym_jiminy.rllib.curriculum import build_task_scheduling_callback
 
 
 # Fix the seed for CI stability
@@ -62,6 +67,7 @@ class DummyTaskWrapper(BaseTaskSettableWrapper):
         return float(score)
 
 
+@unittest.skipIf(not IS_RAY_AVAILABLE, "Ray is not available.")
 class AcrobotTaskCurriculum(unittest.TestCase):
     """ TODO: Write documentation.
     """

--- a/python/jiminy_py/setup.py
+++ b/python/jiminy_py/setup.py
@@ -60,7 +60,7 @@ setup(
     author_email="alexis.duburcq@gmail.com",
     maintainer="Alexis Duburcq",
     license="MIT",
-    python_requires=">=3.10,<3.13",
+    python_requires=">=3.10,<3.14",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Science/Research",
@@ -69,7 +69,8 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12"
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13"
     ],
     keywords="robotics physics simulator",
     distclass=BinaryDistribution,

--- a/python/jiminy_py/src/jiminy_py/log.py
+++ b/python/jiminy_py/src/jiminy_py/log.py
@@ -143,7 +143,7 @@ def build_robot_from_log(
     robot_data = log_constants[".".join(filter(None, (robot_name, "robot")))]
 
     # Load robot from binary data
-    return jiminy.load_from_binary(
+    return jiminy.load_robot_from_binary(
         robot_data, mesh_dir_path, mesh_package_dirs)
 
 

--- a/python/jiminy_py/src/jiminy_py/simulator.py
+++ b/python/jiminy_py/src/jiminy_py/simulator.py
@@ -824,10 +824,14 @@ class Simulator:
         # Enable the ground profile is requested and available
         assert self.viewer is not None and self.viewer.backend is not None
         if update_ground_profile:
+            # Discretize ground profile
             engine_options = self.engine.get_options()
             ground_profile = engine_options["world"]["groundProfile"]
-            Viewer.update_floor(
-                ground_profile, simplify_mesh=True, show_vertices=False)
+            geom = jiminy.discretize_heightmap(
+                ground_profile, *((-10.0, 10.0, 0.04) * 2), must_simplify=True)
+
+            # Update viewer
+            Viewer.update_floor(geom, show_vertices=False)
 
         # Set the camera pose if requested
         if camera_pose is not None:

--- a/python/jiminy_py/src/jiminy_py/viewer/viewer.py
+++ b/python/jiminy_py/src/jiminy_py/viewer/viewer.py
@@ -45,9 +45,7 @@ from pinocchio.rpy import (  # pylint: disable=import-error
     rpyToMatrix, matrixToRpy)
 
 from .. import core as jiminy
-from ..core import (  # pylint: disable=no-name-in-module
-    ContactSensor,
-    discretize_heightmap)
+from ..core import ContactSensor  # pylint: disable=no-name-in-module
 from ..robot import _DuplicateFilter
 from ..dynamics import Trajectory
 from ..log import UpdateHook
@@ -832,7 +830,7 @@ class Viewer:
                                 pose=[frame_pose.translation, None],
                                 remove_if_exists=True,
                                 auto_refresh=False,
-                                radius=0.01)
+                                radius=0.006)
 
             self.display_contact_frames(self._display_contact_frames)
 
@@ -1840,34 +1838,17 @@ class Viewer:
     @staticmethod
     @_with_lock
     @_must_be_open
-    def update_floor(ground_profile: Optional[jiminy.HeightmapFunction] = None,
-                     x_range: Tuple[float, float] = (-10.0, 10.0),
-                     y_range: Tuple[float, float] = (-10.0, 10.0),
-                     grid_unit:  Tuple[float, float] = (0.04, 0.04),
-                     simplify_mesh: bool = False,
+    def update_floor(geom: Optional[hppfcl.CollisionGeometry] = None,
                      show_vertices: bool = False) -> None:
         """Display a custom ground profile as a height map or the original tile
         ground floor.
 
-        :param ground_profile: `jiminy_py.core.HeightmapFunction` associated
-                               with the ground profile. It renders a flat tile
-                               ground if not specified.
-                               Optional: None by default.
-        :param x_range: Tuple gathering min and max limits along x-axis for
-                        which the heightmap mesh associated with the ground
-                        profile will be procedurally generated.
-                        Optional: (-10.0, 10.0) by default.
-        :param y_range: Tuple gathering min and max limits along y-axis.
-                        Optional: (-10.0, 10.0) by default.
-        :param grid_unit: Tuple gathering X and Y discretization steps for the
-                          generation of the heightmap mesh.
-                          Optional: 4cm by default.
-        :param simplify_mesh: Whether the generated heightmap mesh should be
-                              decimated before final rendering. This option
-                              must be enabled for the ratio between grid size
-                              and unit is very large to avoid a prohibitive
-                              slowdown of the viewer.
-                              Optional: False by default
+        :param geom: Collision geometry associated with the ground profile. A
+                     flat tile ground will be rendered if not specified. Note
+                     that symbolic function `jiminy_py.core.HeightmapFunction`
+                     can be converted in collision geometry by calling
+                     `jiminy_py.core.discretize_heightmap`.
+                     Optional: None by default.
         :param show_vertices: Whether to highlight the mesh vertices.
                               Optional: disabled by default.
         """
@@ -1876,13 +1857,6 @@ class Viewer:
         # Assert(s) for type checker
         assert Viewer.backend is not None
         assert Viewer._backend_obj is not None
-
-        # Discretize ground profile if provided
-        geom = None
-        if ground_profile is not None:
-            geom = discretize_heightmap(
-                ground_profile, *x_range, grid_unit[0], *y_range, grid_unit[1],
-                must_simplify=simplify_mesh)
 
         # Render original flat tile ground if possible.
         # TODO: Improve this check using LocalAABB box geometry instead.

--- a/python/jiminy_pywrap/src/helpers.cc
+++ b/python/jiminy_pywrap/src/helpers.cc
@@ -8,6 +8,10 @@
 #include "jiminy/core/utilities/pinocchio.h"
 #include "jiminy/core/utilities/random.h"
 
+#define HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+#include "hpp/fcl/serialization/collision_object.h"  // `serialize<hpp::fcl::CollisionGeometry>`
+#undef HPP_FCL_SKIP_EIGEN_BOOST_SERIALIZATION
+
 #define NO_IMPORT_ARRAY
 #include "jiminy/python/fwd.h"
 #include "jiminy/python/utilities.h"
@@ -88,6 +92,13 @@ namespace jiminy::python
         std::shared_ptr<jiminy::Robot> robot;
         loadFromBinary(robot, data, meshPathDir, meshPackageDirs);
         return robot;
+    }
+
+    hpp::fcl::CollisionGeometryPtr_t buildHeightmapFromBinary(const std::string & data)
+    {
+        hpp::fcl::CollisionGeometryPtr_t heightmap;
+        loadFromBinary(heightmap, data);
+        return heightmap;
     }
 
     np::ndarray solveJMinvJtv(
@@ -366,13 +377,15 @@ namespace jiminy::python
                  bp::arg("build_visual_model") = false,
                  bp::arg("load_visual_meshes") = false));
 
-        bp::def("save_to_binary", &saveRobotToBinary, (bp::arg("robot")));
+        bp::def("save_robot_to_binary", &saveRobotToBinary, (bp::arg("robot")));
 
-        bp::def("load_from_binary",
+        bp::def("load_robot_from_binary",
                 &buildRobotFromBinary,
                 (bp::arg("data"),
                  bp::arg("mesh_dir_path") = bp::object(),
                  bp::arg("mesh_package_dirs") = bp::list()));
+
+        bp::def("load_heightmap_from_binary", &buildHeightmapFromBinary, bp::arg("data"));
 
         bp::def("get_joint_type", &getJointType, bp::arg("joint_model"));
         bp::def(


### PR DESCRIPTION
* [core/python] Fix 'SensorMeasurementTree' not supporting instantiation from 'OrderedDict'. (#867)
* [core|python] Ground profile now included in persistent log files and automatically loaded for replay. (#867)
* [gym_jiminy/common] Move initial state sampling after reset all of the layers of the pipeline. (#867)
* [gym_jiminy/common] Fix 'env.stop' not being called at the end of evaluation if keyboard-interrupted. (#867)
* [gym_jiminy/common] Fix loaded pipeline config file cannot be instantiated more than once. (#867)
* [gym_jiminy/common] Fix 'ScaleObservation' broken for slices. (#868)
* [misc] Add support of Python 3.13. (#868)